### PR TITLE
ci: speed up CI by caching Go modules and mise tools

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -1,0 +1,32 @@
+name: Setup mise (CI subset)
+description: |
+  Install only the trimmed CI tool set defined in mise.ci.toml. Stages the
+  CI config in $RUNNER_TEMP so mise-action's `mise install` reads from there
+  instead of the full repo-root mise.toml. Tools land on PATH globally.
+
+inputs:
+  cache_save:
+    description: |
+      Whether this job should write the mise cache. Set to "true" on exactly
+      one job per workflow (typically `prerequisites`); "false" elsewhere so
+      parallel jobs only restore.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Stage CI mise config
+      shell: bash
+      run: |
+        mkdir -p "$RUNNER_TEMP/mise-ci"
+        cp "$GITHUB_WORKSPACE/mise.ci.toml" "$RUNNER_TEMP/mise-ci/mise.toml"
+
+    - name: Setup mise
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        working_directory: ${{ runner.temp }}/mise-ci
+        cache_save: ${{ inputs.cache_save }}

--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -30,3 +30,7 @@ runs:
         version: 2026.3.7
         working_directory: ${{ runner.temp }}/mise-ci
         cache_save: ${{ inputs.cache_save }}
+        # Key on platform + mise.ci.toml hash only. Omitting {{version}}
+        # keeps the cache valid across the near-daily mise CLI releases — it
+        # would otherwise invalidate every time we bump the pinned version.
+        cache_key: "mise-{{platform}}-{{file_hash}}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,6 +24,16 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
+
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
@@ -62,6 +72,16 @@ jobs:
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
 
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
+
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
@@ -83,6 +103,16 @@ jobs:
 
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -116,6 +146,17 @@ jobs:
 
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
+
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,13 +34,8 @@ jobs:
             sdk/go.sum
             examples/go.sum
 
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
-        with:
-          version: 2026.3.7
-          cache_save: false # Only the prerequisites job saves the mise cache.
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
 
       - name: Run golangci-lint
         # Lint library packages only; cmd/ depends on schema-embed.json which is generated.
@@ -87,13 +82,8 @@ jobs:
             sdk/go.sum
             examples/go.sum
 
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
-        with:
-          version: 2026.3.7
-          cache_save: false # Only the prerequisites job saves the mise cache.
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
 
       - name: go vet
         # Exclude cmd/: depends on schema-embed.json which is generated at build time.
@@ -124,13 +114,10 @@ jobs:
             sdk/go.sum
             examples/go.sum
 
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
         with:
-          version: 2026.3.7
-          cache_save: true # This job populates the mise cache for the rest of the workflow.
+          cache_save: "true" # This job populates the mise cache for the rest of the workflow.
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
@@ -173,13 +160,8 @@ jobs:
             sdk/go.sum
             examples/go.sum
 
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
-        with:
-          version: 2026.3.7
-          cache_save: false # Only the prerequisites job saves the mise cache.
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
@@ -240,13 +222,8 @@ jobs:
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
 
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
-        with:
-          version: 2026.3.7
-          cache_save: false # Only the prerequisites job saves the mise cache.
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,6 +36,11 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: 2026.3.7
+          cache_save: false # Only the prerequisites job saves the mise cache.
 
       - name: Run golangci-lint
         # Lint library packages only; cmd/ depends on schema-embed.json which is generated.
@@ -84,6 +89,11 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: 2026.3.7
+          cache_save: false # Only the prerequisites job saves the mise cache.
 
       - name: go vet
         # Exclude cmd/: depends on schema-embed.json which is generated at build time.
@@ -116,6 +126,11 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: 2026.3.7
+          cache_save: true # This job populates the mise cache for the rest of the workflow.
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
@@ -160,6 +175,11 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: 2026.3.7
+          cache_save: false # Only the prerequisites job saves the mise cache.
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
@@ -222,6 +242,11 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: 2026.3.7
+          cache_save: false # Only the prerequisites job saves the mise cache.
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,10 @@ jobs:
             sdk/go.sum
             examples/go.sum
 
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
         with:
-          version: 2026.3.7
-          cache_save: true # This job populates the mise cache for the rest of the workflow.
+          cache_save: "true" # This job populates the mise cache for the rest of the workflow.
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
@@ -84,13 +81,8 @@ jobs:
             sdk/go.sum
             examples/go.sum
 
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
-        with:
-          version: 2026.3.7
-          cache_save: false # Only the prerequisites job saves the mise cache.
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
 
       - name: Set GoReleaser tag
         # Use the literal pushed tag. pulumictl appends `+<sha>` build metadata to
@@ -138,13 +130,8 @@ jobs:
             sdk/go.sum
             examples/go.sum
 
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        env:
-          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
-        with:
-          version: 2026.3.7
-          cache_save: false # Only the prerequisites job saves the mise cache.
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: 2026.3.7
+          cache_save: true # This job populates the mise cache for the rest of the workflow.
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
@@ -81,6 +86,11 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: 2026.3.7
+          cache_save: false # Only the prerequisites job saves the mise cache.
 
       - name: Set GoReleaser tag
         # Use the literal pushed tag. pulumictl appends `+<sha>` build metadata to
@@ -130,6 +140,11 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: 2026.3.7
+          cache_save: false # Only the prerequisites job saves the mise cache.
 
       - name: Set provider version
         run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,11 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: provider/go.mod
-          cache-dependency-path: provider/go.sum
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -69,7 +73,11 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: provider/go.mod
-          cache-dependency-path: provider/go.sum
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -114,7 +122,11 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: provider/go.mod
-          cache-dependency-path: provider/go.sum
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -1,0 +1,27 @@
+# CI-only mise config. The full dev tool set lives in mise.toml; this file is
+# the trimmed subset GitHub Actions installs via .github/actions/setup-mise.
+# Keep tool versions in sync with mise.toml for everything listed here.
+#
+# Excluded vs. mise.toml: dotnet, java (no SDK matrix entry), gopls (IDE
+# language server), pulumi/upgrade-provider (only used by upgrade-provider.yml,
+# which calls pulumi-upgrade-provider-action and doesn't go through mise).
+
+[settings]
+experimental = true
+fetch_remote_versions_cache = "24h"
+http_retries = 3
+
+[tools]
+github-cli = "latest"
+
+go = "1.25"
+node = "22"
+python = "3.11"
+
+pulumi = "latest"
+uv = "latest"
+golangci-lint = "2"
+"go:github.com/pulumi/pulumictl/cmd/pulumictl" = "latest"
+
+[env]
+GOTOOLCHAIN = "go1.25.9"

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,9 @@ experimental = true # Required for Go binaries (e.g. pulumictl).
 fetch_remote_versions_cache = "24h" # Reduce GitHub API calls to confirm pinned versions.
 http_retries = 3
 
+# Full dev tool set. CI uses a trimmed subset via mise.ci.toml — keep both in
+# sync for tools that CI needs (go, node, python, pulumi, golangci-lint, etc.).
+
 [tools]
 github-cli = "latest"
 
@@ -16,9 +19,8 @@ pulumi = "latest"
 uv = "latest"
 golangci-lint = "2"
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = "latest"
-# Dev-only tools (gopls, upgrade-provider) intentionally omitted: CI doesn't
-# need them and the upgrade-provider workflow uses a separate action. Add to
-# your own ~/.config/mise/config.toml or .mise.local.toml if you want them.
+"go:github.com/pulumi/upgrade-provider" = "main"
+"go:golang.org/x/tools/gopls" = "latest"
 
 [env]
 GOTOOLCHAIN = "go1.25.9"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,7 @@
 [settings]
 experimental = true # Required for Go binaries (e.g. pulumictl).
+fetch_remote_versions_cache = "24h" # Reduce GitHub API calls to confirm pinned versions.
+http_retries = 3
 
 [tools]
 github-cli = "latest"
@@ -14,9 +16,9 @@ pulumi = "latest"
 uv = "latest"
 golangci-lint = "2"
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = "latest"
-"go:github.com/pulumi/upgrade-provider" = "main"
-"go:golang.org/x/tools/gopls" = "latest"
-
+# Dev-only tools (gopls, upgrade-provider) intentionally omitted: CI doesn't
+# need them and the upgrade-provider workflow uses a separate action. Add to
+# your own ~/.config/mise/config.toml or .mise.local.toml if you want them.
 
 [env]
 GOTOOLCHAIN = "go1.25.9"


### PR DESCRIPTION
## Summary

Three CI cache improvements modeled on `pulumi-tf-provider-boilerplate`. Mirrored across `pull-request.yml` and `release.yml`.

### 1. Go module/build cache (commit 1)
Adds `actions/setup-go@v6.4.0` before `mise` in every Go-touching job (`lint`, `go-test`, `prerequisites`, `build_sdk` for the `go` matrix entry). Previously these jobs only ran `jdx/mise-action`, which installs the Go binary but does **not** configure `GOMODCACHE`/`GOCACHE` — so each run re-downloaded all modules and rebuilt from scratch. Uses a multi-file `cache-dependency-path` (`provider/go.sum`, `provider/shim/go.sum`, `sdk/go.sum`, `examples/go.sum`) so the cache key invalidates correctly when any of those files change. `release.yml` already had `setup-go` but with only `provider/go.sum` — expanded to the same multi-file form across all 3 jobs.

### 2. Mise install cache (commit 2)
Pins the mise binary version (`version: 2026.3.7`), adds `MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s`, and sets `cache_save: true` only on `prerequisites` / `cache_save: false` everywhere else so one job populates the cache and the rest restore without write contention. Adds `[settings] fetch_remote_versions_cache = "24h"` and `http_retries = 3` to `mise.toml` to cut version-resolution chatter for floating-version tools.

### 3. CI tool subset via mise.ci.toml + composite action (commit 3)
Splits `mise.toml` (full dev tool set) from `mise.ci.toml` (CI subset). CI no longer installs:
- `gopls` — IDE language server
- `pulumi/upgrade-provider` — only used by `upgrade-provider.yml`, which calls `pulumi-upgrade-provider-action` separately
- `dotnet`, `java` — not in the SDK build matrix

A new composite action `.github/actions/setup-mise` stages `mise.ci.toml` under `$RUNNER_TEMP` and points `jdx/mise-action`'s `working_directory` there, so `mise install` reads only the CI subset without touching the project's `mise.toml`. The composite exposes a single `cache_save` input — set to `"true"` on each workflow's `prerequisites` job, defaulted to `"false"` elsewhere. Replaces inline `Setup mise` blocks in 5 `pull-request.yml` jobs and 3 `release.yml` jobs.

## Test plan
- [ ] First run after merge: cache miss expected; subsequent PRs should restore both Go and mise caches and skip the long install/compile step
- [ ] All jobs still pass: `lint`, `go-test`, `schema-validation`, `prerequisites`, `build_sdk` (nodejs/python/go), `python-tests`
- [ ] On a `mise.ci.toml` or `go.sum` change, cache keys roll over and downstream jobs install fresh once, then cache again
- [ ] Local dev unchanged: `mise install` from repo root still installs the full dev tool set
- [ ] If a tool needs to be added to CI, it must be added to **both** `mise.toml` and `mise.ci.toml` (a comment in each file calls this out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)