### PR TITLE
ci: rewrite upgrade-provider workflow to fix daily cron

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -1,8 +1,6 @@
 name: Upgrade provider
 on:
-  issues:
-    types:
-      - opened
+  workflow_dispatch:
   schedule:
     - cron: '0 5 * * *'
 env:
@@ -16,27 +14,50 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - name: Call upgrade provider action
-        uses: pulumi/pulumi-upgrade-provider-action@12996503de2aaddd72c7426efc43331a8970894f # v0.0.19
-        with:
-          kind: all
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Enable auto-merge on upgrade PRs
-        # Restrict to PRs authored by github-actions[bot] (the action's identity
-        # when GH_TOKEN is GITHUB_TOKEN) on a known upgrade-* branch prefix.
-        # Both filters together prevent ever auto-merging a human PR.
+      - name: Fetch main
+        run: git fetch --depth=1 origin main:main
+        shell: bash
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+        with:
+          version: 2026.3.7
+          cache_save: false
+          cache_key: "mise-full-{{platform}}-{{file_hash}}"
+
+      - name: Install upgrade-provider
+        run: go install github.com/pulumi/upgrade-provider@main
+        shell: bash
+
+      - name: Set up git identity
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        shell: bash
+
+      - name: Run upgrade-provider
+        run: upgrade-provider "$GITHUB_REPOSITORY" --kind=all --allow-missing-docs=true --repo-path=.
+        shell: bash
+
+      - name: Enable auto-merge on upgrade PR
+        # safety filter — both bot author + branch prefix required
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # yamllint disable rule:line-length
         run: |
           set -euo pipefail
-          mapfile -t PRS < <(gh pr list \
-            --state open \
-            --author 'app/github-actions' \
-            --json number,headRefName \
-            --jq '.[] | select(.headRefName | test("^upgrade-(pulumi-terraform-bridge|terraform-provider|pulumi-version)-")) | .number')
-          for pr in "${PRS[@]}"; do
-            echo "Enabling auto-merge on PR #$pr"
-            gh pr merge "$pr" --auto --squash --delete-branch
-          done
-        # yamllint enable rule:line-length
+          BRANCH=$(git branch --show-current)
+          case "$BRANCH" in
+            upgrade-pulumi-terraform-bridge-*|upgrade-terraform-provider-*|upgrade-pulumi-version-*) ;;
+            *) echo "branch $BRANCH not an upgrade branch; skipping"; exit 0 ;;
+          esac
+          AUTHOR=$(gh pr view --json author --jq .author.login)
+          if [ "$AUTHOR" != "app/github-actions" ]; then
+            echo "PR author is $AUTHOR (not app/github-actions); skipping"
+            exit 0
+          fi
+          gh pr merge --auto --squash --delete-branch
+        shell: bash

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ bin/$(TFGEN): provider/resources.go provider/go.*
 # Sentinel: rebuilt only when tfgen binary is newer.
 schema: .make/schema
 
+# upstream upgrade-provider calls this
+tfgen: schema
+
 .make/schema: bin/$(TFGEN)
 	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
 	cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go
@@ -68,6 +71,9 @@ prepare_local_workspace: bin/$(TFGEN) .make/schema bin/$(PROVIDER)
 # This lets CI build all SDKs in parallel after downloading the prerequisites.
 
 build_sdks: build_nodejs build_python build_go build_dotnet
+
+# upstream upgrade-provider calls this
+generate_sdks: build_sdks
 
 build_nodejs: .make/build_nodejs
 


### PR DESCRIPTION
## Summary
- The daily upgrade-provider cron has been broken since at least mid-2025 and now fails fast (panic in upstream `runMiseUpgrade` because the action doesn't install mise; behind that, `make tfgen` / `make generate_sdks` targets don't exist; tool clones from main instead of using the workflow checkout).
- Replace `pulumi/pulumi-upgrade-provider-action` with inlined steps modelled on `pulumi/pulumi-tf-provider-boilerplate` — full `mise.toml` toolchain via `jdx/mise-action`, explicit `go install upgrade-provider@main`, direct CLI call with `--repo-path=.` so it operates on the checked-out ref, GITHUB_TOKEN auth so the auto-merge gate's `app/github-actions` author check still applies.
- Auto-merge step now targets the current upgrade branch's PR directly (`gh pr merge --auto` after a local branch-prefix check + `gh pr view` author check) — no `gh pr list` API race.
- Trigger switched from `issues: opened` to `workflow_dispatch` so we can validate runs on demand; cron unchanged.

## Test plan
- [x] `workflow_dispatch` on this branch — run [25102924385](https://github.com/ryan-pip/pulumi-astronomer/actions/runs/25102924385) green end-to-end (mise install → upgrade-provider → `make tfgen` → `make generate_sdks` → push branch → open PR → enable auto-merge).
- [x] Auto-merge confirmed armed on the test PR ([#43](https://github.com/ryan-pip/pulumi-astronomer/pull/43)) by `app/github-actions` (squash); both safety filters from `.claude/rules/auto-merge-safety.md` exercised.
- [x] `make tfgen` runs locally and produces the expected schema artefacts.
- [x] Lint clean (`hk run check`).
- [ ] Post-merge: confirm next scheduled cron run on `main` opens an `upgrade-*` PR and arms auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)