### PR TITLE
ci: skip Fetch main step when already on main

### DIFF
--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Fetch main
+        if: github.ref != 'refs/heads/main'
         run: git fetch --depth=1 origin main:main
         shell: bash
 


### PR DESCRIPTION
## Summary

The daily scheduled run of \`upgrade-provider.yml\` has been failing because the \`Fetch main\` step (added in da14a03 for off-main \`workflow_dispatch\` runs) does \`git fetch --depth=1 origin main:main\` — which fails when the runner is already checked out on \`main\` (you can't update the currently checked-out branch ref).

Gating the step on \`github.ref != 'refs/heads/main'\` keeps the off-main dispatch case working while letting scheduled runs (and dispatches from main) skip the step entirely.

## Test plan

- [ ] After merge, manually dispatch from \`main\`: \`gh workflow run upgrade-provider.yml --ref main\` — \`Fetch main\` step should show as **skipped** and the job should proceed.
- [ ] Off-main dispatch path is preserved (the \`if:\` only narrows when the step runs); not exercising in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)