### PR TITLE
chore: pin pulumi to 3.233.0 and regenerate SDKs

### DIFF
--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -19,7 +19,7 @@ node = "22"
 python = "3.11"
 dotnet = "8.0"
 
-pulumi = "latest"
+pulumi = "3.233.0"
 uv = "latest"
 golangci-lint = "2"
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -15,7 +15,7 @@ python = "3.11"
 dotnet = "8.0"
 java = "corretto-11"
 
-pulumi = "latest"
+pulumi = "3.233.0"
 uv = "latest"
 golangci-lint = "2"
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = "latest"

--- a/sdk/nodejs/agentToken.ts
+++ b/sdk/nodejs/agentToken.ts
@@ -99,23 +99,23 @@ export interface AgentTokenState {
     /**
      * ID of the deployment this agent token belongs to
      */
-    deploymentId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
     /**
      * Agent Token description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * Agent Token expiry period in days. If not set, the token will not expire.
      */
-    expiryPeriodInDays?: pulumi.Input<number>;
+    expiryPeriodInDays?: pulumi.Input<number | undefined>;
     /**
      * Agent Token name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * Agent Token value. Warning: This value will be saved in plaintext in the terraform state file.
      */
-    token?: pulumi.Input<string>;
+    token?: pulumi.Input<string | undefined>;
 }
 
 /**
@@ -129,13 +129,13 @@ export interface AgentTokenArgs {
     /**
      * Agent Token description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * Agent Token expiry period in days. If not set, the token will not expire.
      */
-    expiryPeriodInDays?: pulumi.Input<number>;
+    expiryPeriodInDays?: pulumi.Input<number | undefined>;
     /**
      * Agent Token name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/sdk/nodejs/alert.ts
+++ b/sdk/nodejs/alert.ts
@@ -174,63 +174,63 @@ export interface AlertState {
     /**
      * Alert creation timestamp
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * Alert creator
      */
-    createdBy?: pulumi.Input<inputs.AlertCreatedBy>;
+    createdBy?: pulumi.Input<inputs.AlertCreatedBy | undefined>;
     /**
      * The ID of the Deployment to which the alert is scoped
      */
-    deploymentId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
     /**
      * The entity ID the alert is associated with
      */
-    entityId?: pulumi.Input<string>;
+    entityId?: pulumi.Input<string | undefined>;
     /**
      * The name of the entity the alert is associated with
      */
-    entityName?: pulumi.Input<string>;
+    entityName?: pulumi.Input<string | undefined>;
     /**
      * The ID of the Deployment to which the alert is scoped
      */
-    entityType?: pulumi.Input<string>;
+    entityType?: pulumi.Input<string | undefined>;
     /**
      * Alert name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * Set of notification channel identifiers to notify when the alert is triggered
      */
-    notificationChannelIds?: pulumi.Input<pulumi.Input<string>[]>;
+    notificationChannelIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * The notification channels to send alerts to
      */
-    notificationChannels?: pulumi.Input<pulumi.Input<inputs.AlertNotificationChannel>[]>;
+    notificationChannels?: pulumi.Input<pulumi.Input<inputs.AlertNotificationChannel>[] | undefined>;
     /**
      * Alert rules defining the conditions for triggering the alert
      */
-    rules?: pulumi.Input<inputs.AlertRules>;
+    rules?: pulumi.Input<inputs.AlertRules | undefined>;
     /**
      * The alert's severity
      */
-    severity?: pulumi.Input<string>;
+    severity?: pulumi.Input<string | undefined>;
     /**
      * The alert's type
      */
-    type?: pulumi.Input<string>;
+    type?: pulumi.Input<string | undefined>;
     /**
      * Alert last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * Alert updater
      */
-    updatedBy?: pulumi.Input<inputs.AlertUpdatedBy>;
+    updatedBy?: pulumi.Input<inputs.AlertUpdatedBy | undefined>;
     /**
      * The ID of the Workspace to which the alert is scoped
      */
-    workspaceId?: pulumi.Input<string>;
+    workspaceId?: pulumi.Input<string | undefined>;
 }
 
 /**
@@ -248,7 +248,7 @@ export interface AlertArgs {
     /**
      * Alert name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * Set of notification channel identifiers to notify when the alert is triggered
      */

--- a/sdk/nodejs/apiToken.ts
+++ b/sdk/nodejs/apiToken.ts
@@ -158,59 +158,59 @@ export interface ApiTokenState {
     /**
      * API Token creation timestamp
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * API Token creator
      */
-    createdBy?: pulumi.Input<inputs.ApiTokenCreatedBy>;
+    createdBy?: pulumi.Input<inputs.ApiTokenCreatedBy | undefined>;
     /**
      * API Token description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * time when the API token will expire in UTC
      */
-    endAt?: pulumi.Input<string>;
+    endAt?: pulumi.Input<string | undefined>;
     /**
      * API Token expiry period in days
      */
-    expiryPeriodInDays?: pulumi.Input<number>;
+    expiryPeriodInDays?: pulumi.Input<number | undefined>;
     /**
      * API Token last used timestamp
      */
-    lastUsedAt?: pulumi.Input<string>;
+    lastUsedAt?: pulumi.Input<string | undefined>;
     /**
      * API Token name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * The roles assigned to the API Token
      */
-    roles?: pulumi.Input<pulumi.Input<inputs.ApiTokenRole>[]>;
+    roles?: pulumi.Input<pulumi.Input<inputs.ApiTokenRole>[] | undefined>;
     /**
      * API Token short token
      */
-    shortToken?: pulumi.Input<string>;
+    shortToken?: pulumi.Input<string | undefined>;
     /**
      * time when the API token will become valid in UTC
      */
-    startAt?: pulumi.Input<string>;
+    startAt?: pulumi.Input<string | undefined>;
     /**
      * API Token value. Warning: This value will be saved in plaintext in the terraform state file.
      */
-    token?: pulumi.Input<string>;
+    token?: pulumi.Input<string | undefined>;
     /**
      * API Token type - if changing this value, the API Token will be recreated with the new type
      */
-    type?: pulumi.Input<string>;
+    type?: pulumi.Input<string | undefined>;
     /**
      * API Token last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * API Token updater
      */
-    updatedBy?: pulumi.Input<inputs.ApiTokenUpdatedBy>;
+    updatedBy?: pulumi.Input<inputs.ApiTokenUpdatedBy | undefined>;
 }
 
 /**
@@ -220,15 +220,15 @@ export interface ApiTokenArgs {
     /**
      * API Token description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * API Token expiry period in days
      */
-    expiryPeriodInDays?: pulumi.Input<number>;
+    expiryPeriodInDays?: pulumi.Input<number | undefined>;
     /**
      * API Token name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * The roles assigned to the API Token
      */

--- a/sdk/nodejs/cluster.ts
+++ b/sdk/nodejs/cluster.ts
@@ -234,104 +234,104 @@ export interface ClusterState {
     /**
      * Cluster cloud provider - if changed, the cluster will be recreated. Allowed values: `AWS`, `GCP`, `AZURE`.
      */
-    cloudProvider?: pulumi.Input<string>;
+    cloudProvider?: pulumi.Input<string | undefined>;
     /**
      * Cluster creation timestamp
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * Cluster database instance type
      */
-    dbInstanceType?: pulumi.Input<string>;
+    dbInstanceType?: pulumi.Input<string | undefined>;
     /**
      * The secondary region for Disaster Recovery. Required when `isDrEnabled` is true. Cannot be changed once set.
      */
-    drRegion?: pulumi.Input<string>;
+    drRegion?: pulumi.Input<string | undefined>;
     /**
      * Secondary CIDR for pod networking in the DR region (AWS only). Cannot be changed once set.
      */
-    drSecondaryVpcCidr?: pulumi.Input<string>;
+    drSecondaryVpcCidr?: pulumi.Input<string | undefined>;
     /**
      * The VPC subnet range for the Disaster Recovery region. Only valid when `isDrEnabled` is true. Cannot be changed once set.
      */
-    drVpcSubnetRange?: pulumi.Input<string>;
+    drVpcSubnetRange?: pulumi.Input<string | undefined>;
     /**
      * Whether to enable S3 Replication Time Control for Disaster Recovery. Only valid when `isDrEnabled` is true (AWS only).
      */
-    enableReplicationTimeControl?: pulumi.Input<boolean>;
+    enableReplicationTimeControl?: pulumi.Input<boolean | undefined>;
     /**
      * Cluster health status
      */
-    healthStatus?: pulumi.Input<inputs.ClusterHealthStatus>;
+    healthStatus?: pulumi.Input<inputs.ClusterHealthStatus | undefined>;
     /**
      * Whether Disaster Recovery is enabled on the cluster. Only supported for AWS clusters. Can only be enabled at cluster creation time. Can be set to `false` to disable DR on an existing cluster.
      */
-    isDrEnabled?: pulumi.Input<boolean>;
+    isDrEnabled?: pulumi.Input<boolean | undefined>;
     /**
      * Whether the cluster is currently failed over to the DR region. Set to `true` to trigger failover; set to `false` to fail back.
      */
-    isFailedOver?: pulumi.Input<boolean>;
+    isFailedOver?: pulumi.Input<boolean | undefined>;
     /**
      * Whether the cluster is limited
      */
-    isLimited?: pulumi.Input<boolean>;
+    isLimited?: pulumi.Input<boolean | undefined>;
     /**
      * Cluster metadata
      */
-    metadata?: pulumi.Input<inputs.ClusterMetadata>;
+    metadata?: pulumi.Input<inputs.ClusterMetadata | undefined>;
     /**
      * Cluster name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * Cluster node pools
      */
-    nodePools?: pulumi.Input<pulumi.Input<inputs.ClusterNodePool>[]>;
+    nodePools?: pulumi.Input<pulumi.Input<inputs.ClusterNodePool>[] | undefined>;
     /**
      * Cluster pod subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
      */
-    podSubnetRange?: pulumi.Input<string>;
+    podSubnetRange?: pulumi.Input<string | undefined>;
     /**
      * Cluster provider account
      */
-    providerAccount?: pulumi.Input<string>;
+    providerAccount?: pulumi.Input<string | undefined>;
     /**
      * Cluster region - if changed, the cluster will be recreated.
      */
-    region?: pulumi.Input<string>;
+    region?: pulumi.Input<string | undefined>;
     /**
      * Cluster service peering range - required for 'GCP' clusters. If changed, the cluster will be recreated.
      */
-    servicePeeringRange?: pulumi.Input<string>;
+    servicePeeringRange?: pulumi.Input<string | undefined>;
     /**
      * Cluster service subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
      */
-    serviceSubnetRange?: pulumi.Input<string>;
+    serviceSubnetRange?: pulumi.Input<string | undefined>;
     /**
      * Cluster status
      */
-    status?: pulumi.Input<string>;
+    status?: pulumi.Input<string | undefined>;
     /**
      * Cluster tenant ID
      */
-    tenantId?: pulumi.Input<string>;
-    timeouts?: pulumi.Input<inputs.ClusterTimeouts>;
+    tenantId?: pulumi.Input<string | undefined>;
+    timeouts?: pulumi.Input<inputs.ClusterTimeouts | undefined>;
     /**
      * Cluster type
      */
-    type?: pulumi.Input<string>;
+    type?: pulumi.Input<string | undefined>;
     /**
      * Cluster last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * Cluster VPC subnet range. If changed, the cluster will be recreated.
      */
-    vpcSubnetRange?: pulumi.Input<string>;
+    vpcSubnetRange?: pulumi.Input<string | undefined>;
     /**
      * Cluster workspace IDs
      */
-    workspaceIds?: pulumi.Input<pulumi.Input<string>[]>;
+    workspaceIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
 }
 
 /**
@@ -345,35 +345,35 @@ export interface ClusterArgs {
     /**
      * The secondary region for Disaster Recovery. Required when `isDrEnabled` is true. Cannot be changed once set.
      */
-    drRegion?: pulumi.Input<string>;
+    drRegion?: pulumi.Input<string | undefined>;
     /**
      * Secondary CIDR for pod networking in the DR region (AWS only). Cannot be changed once set.
      */
-    drSecondaryVpcCidr?: pulumi.Input<string>;
+    drSecondaryVpcCidr?: pulumi.Input<string | undefined>;
     /**
      * The VPC subnet range for the Disaster Recovery region. Only valid when `isDrEnabled` is true. Cannot be changed once set.
      */
-    drVpcSubnetRange?: pulumi.Input<string>;
+    drVpcSubnetRange?: pulumi.Input<string | undefined>;
     /**
      * Whether to enable S3 Replication Time Control for Disaster Recovery. Only valid when `isDrEnabled` is true (AWS only).
      */
-    enableReplicationTimeControl?: pulumi.Input<boolean>;
+    enableReplicationTimeControl?: pulumi.Input<boolean | undefined>;
     /**
      * Whether Disaster Recovery is enabled on the cluster. Only supported for AWS clusters. Can only be enabled at cluster creation time. Can be set to `false` to disable DR on an existing cluster.
      */
-    isDrEnabled?: pulumi.Input<boolean>;
+    isDrEnabled?: pulumi.Input<boolean | undefined>;
     /**
      * Whether the cluster is currently failed over to the DR region. Set to `true` to trigger failover; set to `false` to fail back.
      */
-    isFailedOver?: pulumi.Input<boolean>;
+    isFailedOver?: pulumi.Input<boolean | undefined>;
     /**
      * Cluster name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * Cluster pod subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
      */
-    podSubnetRange?: pulumi.Input<string>;
+    podSubnetRange?: pulumi.Input<string | undefined>;
     /**
      * Cluster region - if changed, the cluster will be recreated.
      */
@@ -381,12 +381,12 @@ export interface ClusterArgs {
     /**
      * Cluster service peering range - required for 'GCP' clusters. If changed, the cluster will be recreated.
      */
-    servicePeeringRange?: pulumi.Input<string>;
+    servicePeeringRange?: pulumi.Input<string | undefined>;
     /**
      * Cluster service subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
      */
-    serviceSubnetRange?: pulumi.Input<string>;
-    timeouts?: pulumi.Input<inputs.ClusterTimeouts>;
+    serviceSubnetRange?: pulumi.Input<string | undefined>;
+    timeouts?: pulumi.Input<inputs.ClusterTimeouts | undefined>;
     /**
      * Cluster type
      */

--- a/sdk/nodejs/customRole.ts
+++ b/sdk/nodejs/customRole.ts
@@ -154,39 +154,39 @@ export interface CustomRoleState {
     /**
      * The time the custom role was created
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * The subject who created the custom role
      */
-    createdBy?: pulumi.Input<inputs.CustomRoleCreatedBy>;
+    createdBy?: pulumi.Input<inputs.CustomRoleCreatedBy | undefined>;
     /**
      * The custom role's description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * The custom role's name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * The custom role's permissions
      */
-    permissions?: pulumi.Input<pulumi.Input<string>[]>;
+    permissions?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * The IDs of Workspaces that the custom role is restricted to
      */
-    restrictedWorkspaceIds?: pulumi.Input<pulumi.Input<string>[]>;
+    restrictedWorkspaceIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * The custom role's scope (DEPLOYMENT or DAG)
      */
-    scopeType?: pulumi.Input<string>;
+    scopeType?: pulumi.Input<string | undefined>;
     /**
      * The time the custom role was last updated
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * The subject who last updated the custom role
      */
-    updatedBy?: pulumi.Input<inputs.CustomRoleUpdatedBy>;
+    updatedBy?: pulumi.Input<inputs.CustomRoleUpdatedBy | undefined>;
 }
 
 /**
@@ -196,11 +196,11 @@ export interface CustomRoleArgs {
     /**
      * The custom role's description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * The custom role's name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * The custom role's permissions
      */
@@ -208,7 +208,7 @@ export interface CustomRoleArgs {
     /**
      * The IDs of Workspaces that the custom role is restricted to
      */
-    restrictedWorkspaceIds?: pulumi.Input<pulumi.Input<string>[]>;
+    restrictedWorkspaceIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * The custom role's scope (DEPLOYMENT or DAG)
      */

--- a/sdk/nodejs/deployment.ts
+++ b/sdk/nodejs/deployment.ts
@@ -390,203 +390,203 @@ export interface DeploymentState {
     /**
      * Deployment Airflow version
      */
-    airflowVersion?: pulumi.Input<string>;
+    airflowVersion?: pulumi.Input<string | undefined>;
     /**
      * Deployment's current Astro Runtime version
      */
-    astroRuntimeVersion?: pulumi.Input<string>;
+    astroRuntimeVersion?: pulumi.Input<string | undefined>;
     /**
      * Deployment cloud provider - required for 'STANDARD' deployments. If changing this value, the deployment will be recreated in the new cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
      */
-    cloudProvider?: pulumi.Input<string>;
+    cloudProvider?: pulumi.Input<string | undefined>;
     /**
      * Deployment cluster identifier - required for 'HYBRID' and 'DEDICATED' deployments. If changing this value, the deployment will be recreated in the new cluster
      */
-    clusterId?: pulumi.Input<string>;
+    clusterId?: pulumi.Input<string | undefined>;
     /**
      * Deployment contact emails
      */
-    contactEmails?: pulumi.Input<pulumi.Input<string>[]>;
+    contactEmails?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * Deployment creation timestamp
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * Deployment creator
      */
-    createdBy?: pulumi.Input<inputs.DeploymentCreatedBy>;
+    createdBy?: pulumi.Input<inputs.DeploymentCreatedBy | undefined>;
     /**
      * Deployment DAG tarball version
      */
-    dagTarballVersion?: pulumi.Input<string>;
+    dagTarballVersion?: pulumi.Input<string | undefined>;
     /**
      * Deployment default task pod CPU - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    defaultTaskPodCpu?: pulumi.Input<string>;
+    defaultTaskPodCpu?: pulumi.Input<string | undefined>;
     /**
      * Deployment default task pod memory - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    defaultTaskPodMemory?: pulumi.Input<string>;
+    defaultTaskPodMemory?: pulumi.Input<string | undefined>;
     /**
      * Deployment description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * Deployment desired DAG tarball version
      */
-    desiredDagTarballVersion?: pulumi.Input<string>;
+    desiredDagTarballVersion?: pulumi.Input<string | undefined>;
     /**
      * Deployment's desired workload identity. The Terraform provider will use this provided workload identity to create the Deployment. If it is not provided the workload identity will be assigned automatically.
      */
-    desiredWorkloadIdentity?: pulumi.Input<string>;
+    desiredWorkloadIdentity?: pulumi.Input<string | undefined>;
     /**
      * Deployment environment variables. When importing a deployment, you must include all environment variables in your configuration. Any variables not specified will be deleted on the next apply. Secret values must be re-entered as the API does not return them.
      */
-    environmentVariables?: pulumi.Input<pulumi.Input<inputs.DeploymentEnvironmentVariable>[]>;
+    environmentVariables?: pulumi.Input<pulumi.Input<inputs.DeploymentEnvironmentVariable>[] | undefined>;
     /**
      * Deployment executor. Allowed values: `CELERY`, `KUBERNETES`, `ASTRO`.
      */
-    executor?: pulumi.Input<string>;
+    executor?: pulumi.Input<string | undefined>;
     /**
      * Deployment external IPs
      */
-    externalIps?: pulumi.Input<pulumi.Input<string>[]>;
+    externalIps?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * Deployment image repository
      */
-    imageRepository?: pulumi.Input<string>;
+    imageRepository?: pulumi.Input<string | undefined>;
     /**
      * Deployment image tag
      */
-    imageTag?: pulumi.Input<string>;
+    imageTag?: pulumi.Input<string | undefined>;
     /**
      * Deployment image version
      */
-    imageVersion?: pulumi.Input<string>;
+    imageVersion?: pulumi.Input<string | undefined>;
     /**
      * Deployment CI/CD enforced
      */
-    isCicdEnforced?: pulumi.Input<boolean>;
+    isCicdEnforced?: pulumi.Input<boolean | undefined>;
     /**
      * Whether DAG deploy is enabled - Changing this value may disrupt your deployment. Read more at https://docs.astronomer.io/astro/deploy-dags#enable-or-disable-dag-only-deploys-on-a-deployment
      */
-    isDagDeployEnabled?: pulumi.Input<boolean>;
+    isDagDeployEnabled?: pulumi.Input<boolean | undefined>;
     /**
      * Deployment development mode - required for 'STANDARD' and 'DEDICATED' deployments. If changing from 'False' to 'True', the deployment will be recreated
      */
-    isDevelopmentMode?: pulumi.Input<boolean>;
+    isDevelopmentMode?: pulumi.Input<boolean | undefined>;
     /**
      * Deployment high availability - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    isHighAvailability?: pulumi.Input<boolean>;
+    isHighAvailability?: pulumi.Input<boolean | undefined>;
     /**
      * Deployment name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * Deployment namespace
      */
-    namespace?: pulumi.Input<string>;
+    namespace?: pulumi.Input<string | undefined>;
     /**
      * Deployment OIDC issuer URL
      */
-    oidcIssuerUrl?: pulumi.Input<string>;
+    oidcIssuerUrl?: pulumi.Input<string | undefined>;
     /**
      * Deployment's original Astro Runtime version. The Terraform provider will use this provided Astro runtime version to create the Deployment. If not provided, defaults to the current Astro runtime version. The Astro runtime version can be updated with your Astro project Dockerfile, but if this value is changed, the Deployment will be recreated with this new Astro runtime version.
      */
-    originalAstroRuntimeVersion?: pulumi.Input<string>;
+    originalAstroRuntimeVersion?: pulumi.Input<string | undefined>;
     /**
      * Deployment region - required for 'STANDARD' deployments. If changing this value, the deployment will be recreated in the new region
      */
-    region?: pulumi.Input<string>;
+    region?: pulumi.Input<string | undefined>;
     /**
      * Deployment remote execution configuration - only for 'DEDICATED' deployments
      */
-    remoteExecution?: pulumi.Input<inputs.DeploymentRemoteExecution>;
+    remoteExecution?: pulumi.Input<inputs.DeploymentRemoteExecution | undefined>;
     /**
      * Deployment resource quota CPU - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    resourceQuotaCpu?: pulumi.Input<string>;
+    resourceQuotaCpu?: pulumi.Input<string | undefined>;
     /**
      * Deployment resource quota memory - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    resourceQuotaMemory?: pulumi.Input<string>;
+    resourceQuotaMemory?: pulumi.Input<string | undefined>;
     /**
      * Deployment scaling spec - only for 'STANDARD' and 'DEDICATED' deployments
      */
-    scalingSpec?: pulumi.Input<inputs.DeploymentScalingSpec>;
+    scalingSpec?: pulumi.Input<inputs.DeploymentScalingSpec | undefined>;
     /**
      * Deployment scaling status
      */
-    scalingStatus?: pulumi.Input<inputs.DeploymentScalingStatus>;
+    scalingStatus?: pulumi.Input<inputs.DeploymentScalingStatus | undefined>;
     /**
      * Deployment scheduler AU - required for 'HYBRID' deployments
      */
-    schedulerAu?: pulumi.Input<number>;
+    schedulerAu?: pulumi.Input<number | undefined>;
     /**
      * Deployment scheduler CPU
      */
-    schedulerCpu?: pulumi.Input<string>;
+    schedulerCpu?: pulumi.Input<string | undefined>;
     /**
      * Deployment scheduler memory
      */
-    schedulerMemory?: pulumi.Input<string>;
+    schedulerMemory?: pulumi.Input<string | undefined>;
     /**
      * Deployment scheduler replicas - required for 'HYBRID' deployments
      */
-    schedulerReplicas?: pulumi.Input<number>;
+    schedulerReplicas?: pulumi.Input<number | undefined>;
     /**
      * Deployment scheduler size - required for 'STANDARD' and 'DEDICATED' deployments. Allowed values: `SMALL`, `MEDIUM`, `LARGE`, `EXTRALARGE`.
      */
-    schedulerSize?: pulumi.Input<string>;
+    schedulerSize?: pulumi.Input<string | undefined>;
     /**
      * Deployment status
      */
-    status?: pulumi.Input<string>;
+    status?: pulumi.Input<string | undefined>;
     /**
      * Deployment status reason
      */
-    statusReason?: pulumi.Input<string>;
+    statusReason?: pulumi.Input<string | undefined>;
     /**
      * Deployment task pod node pool identifier - required if executor is 'KUBERNETES' and type is 'HYBRID'
      */
-    taskPodNodePoolId?: pulumi.Input<string>;
+    taskPodNodePoolId?: pulumi.Input<string | undefined>;
     /**
      * Deployment type - if changing this value, the deployment will be recreated with the new type
      */
-    type?: pulumi.Input<string>;
+    type?: pulumi.Input<string | undefined>;
     /**
      * Deployment last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * Deployment updater
      */
-    updatedBy?: pulumi.Input<inputs.DeploymentUpdatedBy>;
+    updatedBy?: pulumi.Input<inputs.DeploymentUpdatedBy | undefined>;
     /**
      * Deployment webserver Airflow API URL
      */
-    webserverAirflowApiUrl?: pulumi.Input<string>;
+    webserverAirflowApiUrl?: pulumi.Input<string | undefined>;
     /**
      * Deployment webserver ingress hostname
      */
-    webserverIngressHostname?: pulumi.Input<string>;
+    webserverIngressHostname?: pulumi.Input<string | undefined>;
     /**
      * Deployment webserver URL
      */
-    webserverUrl?: pulumi.Input<string>;
+    webserverUrl?: pulumi.Input<string | undefined>;
     /**
      * Deployment worker queues - required for deployments with 'CELERY' executor. For 'STANDARD' and 'DEDICATED' deployments, use astro*machine. For 'HYBRID' deployments, use node*pool*id.
      */
-    workerQueues?: pulumi.Input<pulumi.Input<inputs.DeploymentWorkerQueue>[]>;
+    workerQueues?: pulumi.Input<pulumi.Input<inputs.DeploymentWorkerQueue>[] | undefined>;
     /**
      * Deployment workload identity. This value can be changed via the Astro API if applicable.
      */
-    workloadIdentity?: pulumi.Input<string>;
+    workloadIdentity?: pulumi.Input<string | undefined>;
     /**
      * Deployment workspace identifier - if changing this value, the deployment will be recreated in the new workspace
      */
-    workspaceId?: pulumi.Input<string>;
+    workspaceId?: pulumi.Input<string | undefined>;
 }
 
 /**
@@ -596,11 +596,11 @@ export interface DeploymentArgs {
     /**
      * Deployment cloud provider - required for 'STANDARD' deployments. If changing this value, the deployment will be recreated in the new cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
      */
-    cloudProvider?: pulumi.Input<string>;
+    cloudProvider?: pulumi.Input<string | undefined>;
     /**
      * Deployment cluster identifier - required for 'HYBRID' and 'DEDICATED' deployments. If changing this value, the deployment will be recreated in the new cluster
      */
-    clusterId?: pulumi.Input<string>;
+    clusterId?: pulumi.Input<string | undefined>;
     /**
      * Deployment contact emails
      */
@@ -608,11 +608,11 @@ export interface DeploymentArgs {
     /**
      * Deployment default task pod CPU - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    defaultTaskPodCpu?: pulumi.Input<string>;
+    defaultTaskPodCpu?: pulumi.Input<string | undefined>;
     /**
      * Deployment default task pod memory - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    defaultTaskPodMemory?: pulumi.Input<string>;
+    defaultTaskPodMemory?: pulumi.Input<string | undefined>;
     /**
      * Deployment description
      */
@@ -620,7 +620,7 @@ export interface DeploymentArgs {
     /**
      * Deployment's desired workload identity. The Terraform provider will use this provided workload identity to create the Deployment. If it is not provided the workload identity will be assigned automatically.
      */
-    desiredWorkloadIdentity?: pulumi.Input<string>;
+    desiredWorkloadIdentity?: pulumi.Input<string | undefined>;
     /**
      * Deployment environment variables. When importing a deployment, you must include all environment variables in your configuration. Any variables not specified will be deleted on the next apply. Secret values must be re-entered as the API does not return them.
      */
@@ -640,55 +640,55 @@ export interface DeploymentArgs {
     /**
      * Deployment development mode - required for 'STANDARD' and 'DEDICATED' deployments. If changing from 'False' to 'True', the deployment will be recreated
      */
-    isDevelopmentMode?: pulumi.Input<boolean>;
+    isDevelopmentMode?: pulumi.Input<boolean | undefined>;
     /**
      * Deployment high availability - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    isHighAvailability?: pulumi.Input<boolean>;
+    isHighAvailability?: pulumi.Input<boolean | undefined>;
     /**
      * Deployment name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * Deployment's original Astro Runtime version. The Terraform provider will use this provided Astro runtime version to create the Deployment. If not provided, defaults to the current Astro runtime version. The Astro runtime version can be updated with your Astro project Dockerfile, but if this value is changed, the Deployment will be recreated with this new Astro runtime version.
      */
-    originalAstroRuntimeVersion?: pulumi.Input<string>;
+    originalAstroRuntimeVersion?: pulumi.Input<string | undefined>;
     /**
      * Deployment region - required for 'STANDARD' deployments. If changing this value, the deployment will be recreated in the new region
      */
-    region?: pulumi.Input<string>;
+    region?: pulumi.Input<string | undefined>;
     /**
      * Deployment remote execution configuration - only for 'DEDICATED' deployments
      */
-    remoteExecution?: pulumi.Input<inputs.DeploymentRemoteExecution>;
+    remoteExecution?: pulumi.Input<inputs.DeploymentRemoteExecution | undefined>;
     /**
      * Deployment resource quota CPU - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    resourceQuotaCpu?: pulumi.Input<string>;
+    resourceQuotaCpu?: pulumi.Input<string | undefined>;
     /**
      * Deployment resource quota memory - required for 'STANDARD' and 'DEDICATED' deployments
      */
-    resourceQuotaMemory?: pulumi.Input<string>;
+    resourceQuotaMemory?: pulumi.Input<string | undefined>;
     /**
      * Deployment scaling spec - only for 'STANDARD' and 'DEDICATED' deployments
      */
-    scalingSpec?: pulumi.Input<inputs.DeploymentScalingSpec>;
+    scalingSpec?: pulumi.Input<inputs.DeploymentScalingSpec | undefined>;
     /**
      * Deployment scheduler AU - required for 'HYBRID' deployments
      */
-    schedulerAu?: pulumi.Input<number>;
+    schedulerAu?: pulumi.Input<number | undefined>;
     /**
      * Deployment scheduler replicas - required for 'HYBRID' deployments
      */
-    schedulerReplicas?: pulumi.Input<number>;
+    schedulerReplicas?: pulumi.Input<number | undefined>;
     /**
      * Deployment scheduler size - required for 'STANDARD' and 'DEDICATED' deployments. Allowed values: `SMALL`, `MEDIUM`, `LARGE`, `EXTRALARGE`.
      */
-    schedulerSize?: pulumi.Input<string>;
+    schedulerSize?: pulumi.Input<string | undefined>;
     /**
      * Deployment task pod node pool identifier - required if executor is 'KUBERNETES' and type is 'HYBRID'
      */
-    taskPodNodePoolId?: pulumi.Input<string>;
+    taskPodNodePoolId?: pulumi.Input<string | undefined>;
     /**
      * Deployment type - if changing this value, the deployment will be recreated with the new type
      */
@@ -696,7 +696,7 @@ export interface DeploymentArgs {
     /**
      * Deployment worker queues - required for deployments with 'CELERY' executor. For 'STANDARD' and 'DEDICATED' deployments, use astro*machine. For 'HYBRID' deployments, use node*pool*id.
      */
-    workerQueues?: pulumi.Input<pulumi.Input<inputs.DeploymentWorkerQueue>[]>;
+    workerQueues?: pulumi.Input<pulumi.Input<inputs.DeploymentWorkerQueue>[] | undefined>;
     /**
      * Deployment workspace identifier - if changing this value, the deployment will be recreated in the new workspace
      */

--- a/sdk/nodejs/getAlerts.ts
+++ b/sdk/nodejs/getAlerts.ts
@@ -122,9 +122,9 @@ export function getAlertsOutput(args?: GetAlertsOutputArgs, opts?: pulumi.Invoke
  * A collection of arguments for invoking getAlerts.
  */
 export interface GetAlertsOutputArgs {
-    alertIds?: pulumi.Input<pulumi.Input<string>[]>;
-    alertTypes?: pulumi.Input<pulumi.Input<string>[]>;
-    deploymentIds?: pulumi.Input<pulumi.Input<string>[]>;
-    entityType?: pulumi.Input<string>;
-    workspaceIds?: pulumi.Input<pulumi.Input<string>[]>;
+    alertIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    alertTypes?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    deploymentIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    entityType?: pulumi.Input<string | undefined>;
+    workspaceIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
 }

--- a/sdk/nodejs/getApiTokens.ts
+++ b/sdk/nodejs/getApiTokens.ts
@@ -96,7 +96,7 @@ export function getApiTokensOutput(args?: GetApiTokensOutputArgs, opts?: pulumi.
  * A collection of arguments for invoking getApiTokens.
  */
 export interface GetApiTokensOutputArgs {
-    deploymentId?: pulumi.Input<string>;
-    includeOnlyOrganizationTokens?: pulumi.Input<boolean>;
-    workspaceId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
+    includeOnlyOrganizationTokens?: pulumi.Input<boolean | undefined>;
+    workspaceId?: pulumi.Input<string | undefined>;
 }

--- a/sdk/nodejs/getClusterOptions.ts
+++ b/sdk/nodejs/getClusterOptions.ts
@@ -93,6 +93,6 @@ export interface GetClusterOptionsOutputArgs {
     /**
      * ClusterOptions cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
      */
-    cloudProvider?: pulumi.Input<string>;
+    cloudProvider?: pulumi.Input<string | undefined>;
     type: pulumi.Input<string>;
 }

--- a/sdk/nodejs/getClusters.ts
+++ b/sdk/nodejs/getClusters.ts
@@ -95,6 +95,6 @@ export interface GetClustersOutputArgs {
     /**
      * Clusters cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
      */
-    cloudProvider?: pulumi.Input<string>;
-    names?: pulumi.Input<pulumi.Input<string>[]>;
+    cloudProvider?: pulumi.Input<string | undefined>;
+    names?: pulumi.Input<pulumi.Input<string>[] | undefined>;
 }

--- a/sdk/nodejs/getDeploymentOptions.ts
+++ b/sdk/nodejs/getDeploymentOptions.ts
@@ -160,17 +160,17 @@ export interface GetDeploymentOptionsOutputArgs {
     /**
      * Cloud provider
      */
-    cloudProvider?: pulumi.Input<string>;
+    cloudProvider?: pulumi.Input<string | undefined>;
     /**
      * Deployment ID
      */
-    deploymentId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
     /**
      * Deployment type
      */
-    deploymentType?: pulumi.Input<string>;
+    deploymentType?: pulumi.Input<string | undefined>;
     /**
      * Executor. Valid values: CELERY, KUBERNETES, ASTRO.
      */
-    executor?: pulumi.Input<string>;
+    executor?: pulumi.Input<string | undefined>;
 }

--- a/sdk/nodejs/getDeployments.ts
+++ b/sdk/nodejs/getDeployments.ts
@@ -96,7 +96,7 @@ export function getDeploymentsOutput(args?: GetDeploymentsOutputArgs, opts?: pul
  * A collection of arguments for invoking getDeployments.
  */
 export interface GetDeploymentsOutputArgs {
-    deploymentIds?: pulumi.Input<pulumi.Input<string>[]>;
-    names?: pulumi.Input<pulumi.Input<string>[]>;
-    workspaceIds?: pulumi.Input<pulumi.Input<string>[]>;
+    deploymentIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    names?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    workspaceIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
 }

--- a/sdk/nodejs/getNotificationChannels.ts
+++ b/sdk/nodejs/getNotificationChannels.ts
@@ -70,9 +70,9 @@ export function getNotificationChannelsOutput(args?: GetNotificationChannelsOutp
  * A collection of arguments for invoking getNotificationChannels.
  */
 export interface GetNotificationChannelsOutputArgs {
-    channelTypes?: pulumi.Input<pulumi.Input<string>[]>;
-    deploymentIds?: pulumi.Input<pulumi.Input<string>[]>;
-    entityType?: pulumi.Input<string>;
-    notificationChannelIds?: pulumi.Input<pulumi.Input<string>[]>;
-    workspaceIds?: pulumi.Input<pulumi.Input<string>[]>;
+    channelTypes?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    deploymentIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    entityType?: pulumi.Input<string | undefined>;
+    notificationChannelIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    workspaceIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
 }

--- a/sdk/nodejs/getTeams.ts
+++ b/sdk/nodejs/getTeams.ts
@@ -90,5 +90,5 @@ export function getTeamsOutput(args?: GetTeamsOutputArgs, opts?: pulumi.InvokeOu
  * A collection of arguments for invoking getTeams.
  */
 export interface GetTeamsOutputArgs {
-    names?: pulumi.Input<pulumi.Input<string>[]>;
+    names?: pulumi.Input<pulumi.Input<string>[] | undefined>;
 }

--- a/sdk/nodejs/getUsers.ts
+++ b/sdk/nodejs/getUsers.ts
@@ -94,6 +94,6 @@ export function getUsersOutput(args?: GetUsersOutputArgs, opts?: pulumi.InvokeOu
  * A collection of arguments for invoking getUsers.
  */
 export interface GetUsersOutputArgs {
-    deploymentId?: pulumi.Input<string>;
-    workspaceId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
+    workspaceId?: pulumi.Input<string | undefined>;
 }

--- a/sdk/nodejs/getWorkspaces.ts
+++ b/sdk/nodejs/getWorkspaces.ts
@@ -106,6 +106,6 @@ export function getWorkspacesOutput(args?: GetWorkspacesOutputArgs, opts?: pulum
  * A collection of arguments for invoking getWorkspaces.
  */
 export interface GetWorkspacesOutputArgs {
-    names?: pulumi.Input<pulumi.Input<string>[]>;
-    workspaceIds?: pulumi.Input<pulumi.Input<string>[]>;
+    names?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    workspaceIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
 }

--- a/sdk/nodejs/hybridClusterWorkspaceAuthorization.ts
+++ b/sdk/nodejs/hybridClusterWorkspaceAuthorization.ts
@@ -79,11 +79,11 @@ export interface HybridClusterWorkspaceAuthorizationState {
     /**
      * The ID of the hybrid cluster to set authorizations for
      */
-    clusterId?: pulumi.Input<string>;
+    clusterId?: pulumi.Input<string | undefined>;
     /**
      * The IDs of the workspaces to authorize for the hybrid cluster
      */
-    workspaceIds?: pulumi.Input<pulumi.Input<string>[]>;
+    workspaceIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
 }
 
 /**
@@ -97,5 +97,5 @@ export interface HybridClusterWorkspaceAuthorizationArgs {
     /**
      * The IDs of the workspaces to authorize for the hybrid cluster
      */
-    workspaceIds?: pulumi.Input<pulumi.Input<string>[]>;
+    workspaceIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
 }

--- a/sdk/nodejs/notificationChannel.ts
+++ b/sdk/nodejs/notificationChannel.ts
@@ -156,55 +156,55 @@ export interface NotificationChannelState {
     /**
      * Notification Channel creation timestamp
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * Notification Channel creator
      */
-    createdBy?: pulumi.Input<inputs.NotificationChannelCreatedBy>;
+    createdBy?: pulumi.Input<inputs.NotificationChannelCreatedBy | undefined>;
     /**
      * The notification channel's definition
      */
-    definition?: pulumi.Input<inputs.NotificationChannelDefinition>;
+    definition?: pulumi.Input<inputs.NotificationChannelDefinition | undefined>;
     /**
      * The deployment ID the notification channel is scoped to
      */
-    deploymentId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
     /**
      * The entity ID the notification channel is scoped to
      */
-    entityId?: pulumi.Input<string>;
+    entityId?: pulumi.Input<string | undefined>;
     /**
      * The name of the entity the notification channel is scoped to
      */
-    entityName?: pulumi.Input<string>;
+    entityName?: pulumi.Input<string | undefined>;
     /**
      * The type of entity the notification channel is scoped to (e.g., 'DEPLOYMENT')
      */
-    entityType?: pulumi.Input<string>;
+    entityType?: pulumi.Input<string | undefined>;
     /**
      * When entity type is scoped to ORGANIZATION or WORKSPACE, this determines if child entities can access this notification channel.
      */
-    isShared?: pulumi.Input<boolean>;
+    isShared?: pulumi.Input<boolean | undefined>;
     /**
      * The notification channel's name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * The notification channel's type
      */
-    type?: pulumi.Input<string>;
+    type?: pulumi.Input<string | undefined>;
     /**
      * Notification Channel last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * Notification Channel updater
      */
-    updatedBy?: pulumi.Input<inputs.NotificationChannelUpdatedBy>;
+    updatedBy?: pulumi.Input<inputs.NotificationChannelUpdatedBy | undefined>;
     /**
      * The workspace ID the notification channel is scoped to
      */
-    workspaceId?: pulumi.Input<string>;
+    workspaceId?: pulumi.Input<string | undefined>;
 }
 
 /**
@@ -226,11 +226,11 @@ export interface NotificationChannelArgs {
     /**
      * When entity type is scoped to ORGANIZATION or WORKSPACE, this determines if child entities can access this notification channel.
      */
-    isShared?: pulumi.Input<boolean>;
+    isShared?: pulumi.Input<boolean | undefined>;
     /**
      * The notification channel's name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * The notification channel's type
      */

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -76,15 +76,15 @@ export interface ProviderArgs {
     /**
      * API host to use for the provider. Default is `https://api.astronomer.io`
      */
-    host?: pulumi.Input<string>;
+    host?: pulumi.Input<string | undefined>;
     /**
      * Organization ID this provider will operate on.
      */
-    organizationId?: pulumi.Input<string>;
+    organizationId?: pulumi.Input<string | undefined>;
     /**
      * Astro API Token. Can be set with an `ASTRO_API_TOKEN` env var.
      */
-    token?: pulumi.Input<string>;
+    token?: pulumi.Input<string | undefined>;
 }
 
 export namespace Provider {

--- a/sdk/nodejs/team.ts
+++ b/sdk/nodejs/team.ts
@@ -147,55 +147,55 @@ export interface TeamState {
     /**
      * Team creation timestamp
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * Team creator
      */
-    createdBy?: pulumi.Input<inputs.TeamCreatedBy>;
+    createdBy?: pulumi.Input<inputs.TeamCreatedBy | undefined>;
     /**
      * The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dagRoles` must also have a corresponding entry in `deploymentRoles` (for example `DEPLOYMENT_ACCESSOR`).
      */
-    dagRoles?: pulumi.Input<pulumi.Input<inputs.TeamDagRole>[]>;
+    dagRoles?: pulumi.Input<pulumi.Input<inputs.TeamDagRole>[] | undefined>;
     /**
      * The roles to assign to the Deployments. Each `deploymentId` must belong to a workspace that also appears in `workspaceRoles`. Required for any deployment referenced in `dagRoles`.
      */
-    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.TeamDeploymentRole>[]>;
+    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.TeamDeploymentRole>[] | undefined>;
     /**
      * Team description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * Whether the Team is managed by an identity provider
      */
-    isIdpManaged?: pulumi.Input<boolean>;
+    isIdpManaged?: pulumi.Input<boolean | undefined>;
     /**
      * The IDs of the users to add to the Team
      */
-    memberIds?: pulumi.Input<pulumi.Input<string>[]>;
+    memberIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * Team name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * The role to assign to the Organization
      */
-    organizationRole?: pulumi.Input<string>;
+    organizationRole?: pulumi.Input<string | undefined>;
     /**
      * Number of roles assigned to the Team
      */
-    rolesCount?: pulumi.Input<number>;
+    rolesCount?: pulumi.Input<number | undefined>;
     /**
      * Team last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * Team updater
      */
-    updatedBy?: pulumi.Input<inputs.TeamUpdatedBy>;
+    updatedBy?: pulumi.Input<inputs.TeamUpdatedBy | undefined>;
     /**
      * The roles to assign to the Workspaces. When you set `deploymentRoles` or `dagRoles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
      */
-    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.TeamWorkspaceRole>[]>;
+    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.TeamWorkspaceRole>[] | undefined>;
 }
 
 /**
@@ -205,23 +205,23 @@ export interface TeamArgs {
     /**
      * The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dagRoles` must also have a corresponding entry in `deploymentRoles` (for example `DEPLOYMENT_ACCESSOR`).
      */
-    dagRoles?: pulumi.Input<pulumi.Input<inputs.TeamDagRole>[]>;
+    dagRoles?: pulumi.Input<pulumi.Input<inputs.TeamDagRole>[] | undefined>;
     /**
      * The roles to assign to the Deployments. Each `deploymentId` must belong to a workspace that also appears in `workspaceRoles`. Required for any deployment referenced in `dagRoles`.
      */
-    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.TeamDeploymentRole>[]>;
+    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.TeamDeploymentRole>[] | undefined>;
     /**
      * Team description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * The IDs of the users to add to the Team
      */
-    memberIds?: pulumi.Input<pulumi.Input<string>[]>;
+    memberIds?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * Team name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * The role to assign to the Organization
      */
@@ -229,5 +229,5 @@ export interface TeamArgs {
     /**
      * The roles to assign to the Workspaces. When you set `deploymentRoles` or `dagRoles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
      */
-    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.TeamWorkspaceRole>[]>;
+    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.TeamWorkspaceRole>[] | undefined>;
 }

--- a/sdk/nodejs/teamMembership.ts
+++ b/sdk/nodejs/teamMembership.ts
@@ -84,11 +84,11 @@ export interface TeamMembershipState {
     /**
      * The ID of the team
      */
-    teamId?: pulumi.Input<string>;
+    teamId?: pulumi.Input<string | undefined>;
     /**
      * The ID of the user to add to the team
      */
-    userId?: pulumi.Input<string>;
+    userId?: pulumi.Input<string | undefined>;
 }
 
 /**

--- a/sdk/nodejs/teamRoles.ts
+++ b/sdk/nodejs/teamRoles.ts
@@ -102,23 +102,23 @@ export interface TeamRolesState {
     /**
      * The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dagRoles` must also have a corresponding entry in `deploymentRoles` (e.g. with `DEPLOYMENT_ACCESSOR` role).
      */
-    dagRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesDagRole>[]>;
+    dagRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesDagRole>[] | undefined>;
     /**
      * The roles to assign to the deployments. Each `deploymentId` must belong to a workspace that also appears in `workspaceRoles`. Required for any deployment referenced in `dagRoles`.
      */
-    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesDeploymentRole>[]>;
+    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesDeploymentRole>[] | undefined>;
     /**
      * The role to assign to the organization
      */
-    organizationRole?: pulumi.Input<string>;
+    organizationRole?: pulumi.Input<string | undefined>;
     /**
      * The ID of the team to assign the roles to
      */
-    teamId?: pulumi.Input<string>;
+    teamId?: pulumi.Input<string | undefined>;
     /**
      * The roles to assign to the workspaces. When you set `deploymentRoles` or `dagRoles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
      */
-    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesWorkspaceRole>[]>;
+    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesWorkspaceRole>[] | undefined>;
 }
 
 /**
@@ -128,11 +128,11 @@ export interface TeamRolesArgs {
     /**
      * The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dagRoles` must also have a corresponding entry in `deploymentRoles` (e.g. with `DEPLOYMENT_ACCESSOR` role).
      */
-    dagRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesDagRole>[]>;
+    dagRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesDagRole>[] | undefined>;
     /**
      * The roles to assign to the deployments. Each `deploymentId` must belong to a workspace that also appears in `workspaceRoles`. Required for any deployment referenced in `dagRoles`.
      */
-    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesDeploymentRole>[]>;
+    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesDeploymentRole>[] | undefined>;
     /**
      * The role to assign to the organization
      */
@@ -144,5 +144,5 @@ export interface TeamRolesArgs {
     /**
      * The roles to assign to the workspaces. When you set `deploymentRoles` or `dagRoles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
      */
-    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesWorkspaceRole>[]>;
+    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.TeamRolesWorkspaceRole>[] | undefined>;
 }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -6,23 +6,23 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 
 export interface AlertCreatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface AlertNotificationChannel {
     /**
      * Notification Channel creation timestamp
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * Notification Channel creator
      */
-    createdBy?: pulumi.Input<inputs.AlertNotificationChannelCreatedBy>;
+    createdBy?: pulumi.Input<inputs.AlertNotificationChannelCreatedBy | undefined>;
     /**
      * The notification channel's definition
      */
@@ -30,7 +30,7 @@ export interface AlertNotificationChannel {
     /**
      * The deployment ID the notification channel is scoped to
      */
-    deploymentId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
     /**
      * The entity ID the notification channel is scoped to
      */
@@ -38,7 +38,7 @@ export interface AlertNotificationChannel {
     /**
      * The name of the entity the notification channel is scoped to
      */
-    entityName?: pulumi.Input<string>;
+    entityName?: pulumi.Input<string | undefined>;
     /**
      * The type of entity the notification channel is scoped to (e.g., 'DEPLOYMENT')
      */
@@ -46,11 +46,11 @@ export interface AlertNotificationChannel {
     /**
      * The notification channel's ID
      */
-    id?: pulumi.Input<string>;
+    id?: pulumi.Input<string | undefined>;
     /**
      * When entity type is scoped to ORGANIZATION or WORKSPACE, this determines if child entities can access this notification channel.
      */
-    isShared?: pulumi.Input<boolean>;
+    isShared?: pulumi.Input<boolean | undefined>;
     /**
      * The notification channel's name
      */
@@ -62,64 +62,64 @@ export interface AlertNotificationChannel {
     /**
      * Notification Channel last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * Notification Channel updater
      */
-    updatedBy?: pulumi.Input<inputs.AlertNotificationChannelUpdatedBy>;
+    updatedBy?: pulumi.Input<inputs.AlertNotificationChannelUpdatedBy | undefined>;
     /**
      * The workspace ID the notification channel is scoped to
      */
-    workspaceId?: pulumi.Input<string>;
+    workspaceId?: pulumi.Input<string | undefined>;
 }
 
 export interface AlertNotificationChannelCreatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface AlertNotificationChannelDefinition {
     /**
      * The API key for the notification channel
      */
-    apiKey?: pulumi.Input<string>;
+    apiKey?: pulumi.Input<string | undefined>;
     /**
      * The DAG ID for the notification channel
      */
-    dagId?: pulumi.Input<string>;
+    dagId?: pulumi.Input<string | undefined>;
     /**
      * The deployment API token for the notification channel
      */
-    deploymentApiToken?: pulumi.Input<string>;
+    deploymentApiToken?: pulumi.Input<string | undefined>;
     /**
      * The deployment ID for the notification channel
      */
-    deploymentId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
     /**
      * The integration key for the notification channel
      */
-    integrationKey?: pulumi.Input<string>;
+    integrationKey?: pulumi.Input<string | undefined>;
     /**
      * The recipients for the notification channel
      */
-    recipients?: pulumi.Input<pulumi.Input<string>[]>;
+    recipients?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * The webhook URL for the notification channel
      */
-    webhookUrl?: pulumi.Input<string>;
+    webhookUrl?: pulumi.Input<string | undefined>;
 }
 
 export interface AlertNotificationChannelUpdatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface AlertRules {
@@ -152,15 +152,15 @@ export interface AlertRulesProperties {
     /**
      * The deadline for the DAG in HH:MM 24-hour UTC format
      */
-    dagDeadline?: pulumi.Input<string>;
+    dagDeadline?: pulumi.Input<string | undefined>;
     /**
      * The duration of the DAG in seconds (minimum 60)
      */
-    dagDurationSeconds?: pulumi.Input<number>;
+    dagDurationSeconds?: pulumi.Input<number | undefined>;
     /**
      * The days of the week for the timeliness rule
      */
-    daysOfWeeks?: pulumi.Input<pulumi.Input<string>[]>;
+    daysOfWeeks?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * The ID of the deployment for the alert rule
      */
@@ -168,36 +168,36 @@ export interface AlertRulesProperties {
     /**
      * The look-back period in seconds (minimum 60)
      */
-    lookBackPeriodSeconds?: pulumi.Input<number>;
+    lookBackPeriodSeconds?: pulumi.Input<number | undefined>;
     /**
      * The duration of the Task in seconds (minimum 60)
      */
-    taskDurationSeconds?: pulumi.Input<number>;
+    taskDurationSeconds?: pulumi.Input<number | undefined>;
 }
 
 export interface AlertUpdatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface ApiTokenCreatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface ApiTokenRole {
     /**
      * The Deployment ID. Required for DAG and TAG entity types.
      */
-    deploymentId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
     /**
      * The ID of the entity to assign the role to. For DAG entity type, this is the dag_id. For TAG entity type, this is the tag value.
      */
@@ -213,138 +213,138 @@ export interface ApiTokenRole {
 }
 
 export interface ApiTokenUpdatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface ClusterHealthStatus {
     /**
      * Cluster health status details
      */
-    details?: pulumi.Input<pulumi.Input<inputs.ClusterHealthStatusDetail>[]>;
+    details?: pulumi.Input<pulumi.Input<inputs.ClusterHealthStatusDetail>[] | undefined>;
     /**
      * Cluster health status value
      */
-    value?: pulumi.Input<string>;
+    value?: pulumi.Input<string | undefined>;
 }
 
 export interface ClusterHealthStatusDetail {
     /**
      * Cluster health status detail code
      */
-    code?: pulumi.Input<string>;
+    code?: pulumi.Input<string | undefined>;
     /**
      * Cluster health status detail description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * Cluster health status detail severity
      */
-    severity?: pulumi.Input<string>;
+    severity?: pulumi.Input<string | undefined>;
 }
 
 export interface ClusterMetadata {
     /**
      * Cluster external IPs
      */
-    externalIps?: pulumi.Input<pulumi.Input<string>[]>;
+    externalIps?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * Cluster kube DNS IP
      */
-    kubeDnsIp?: pulumi.Input<string>;
+    kubeDnsIp?: pulumi.Input<string | undefined>;
     /**
      * Cluster OIDC issuer URL
      */
-    oidcIssuerUrl?: pulumi.Input<string>;
+    oidcIssuerUrl?: pulumi.Input<string | undefined>;
 }
 
 export interface ClusterNodePool {
     /**
      * Node pool cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
      */
-    cloudProvider?: pulumi.Input<string>;
+    cloudProvider?: pulumi.Input<string | undefined>;
     /**
      * Node pool cluster identifier
      */
-    clusterId?: pulumi.Input<string>;
+    clusterId?: pulumi.Input<string | undefined>;
     /**
      * Node pool creation timestamp
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * Node pool identifier
      */
-    id?: pulumi.Input<string>;
+    id?: pulumi.Input<string | undefined>;
     /**
      * Whether the node pool is the default node pool of the cluster
      */
-    isDefault?: pulumi.Input<boolean>;
+    isDefault?: pulumi.Input<boolean | undefined>;
     /**
      * Node pool maximum node count
      */
-    maxNodeCount?: pulumi.Input<number>;
+    maxNodeCount?: pulumi.Input<number | undefined>;
     /**
      * Node pool name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * Node pool node instance type
      */
-    nodeInstanceType?: pulumi.Input<string>;
+    nodeInstanceType?: pulumi.Input<string | undefined>;
     /**
      * Node pool supported Astro machines
      */
-    supportedAstroMachines?: pulumi.Input<pulumi.Input<string>[]>;
+    supportedAstroMachines?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * Node pool last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
 }
 
 export interface ClusterTimeouts {
     /**
      * A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
      */
-    create?: pulumi.Input<string>;
+    create?: pulumi.Input<string | undefined>;
     /**
      * A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
      */
-    delete?: pulumi.Input<string>;
+    delete?: pulumi.Input<string | undefined>;
     /**
      * A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
      */
-    update?: pulumi.Input<string>;
+    update?: pulumi.Input<string | undefined>;
 }
 
 export interface CustomRoleCreatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface CustomRoleUpdatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface DeploymentCreatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface DeploymentEnvironmentVariable {
@@ -359,18 +359,18 @@ export interface DeploymentEnvironmentVariable {
     /**
      * Environment variable last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * Environment variable value
      */
-    value?: pulumi.Input<string>;
+    value?: pulumi.Input<string | undefined>;
 }
 
 export interface DeploymentRemoteExecution {
     /**
      * The allowed IP address ranges for remote execution
      */
-    allowedIpAddressRanges?: pulumi.Input<pulumi.Input<string>[]>;
+    allowedIpAddressRanges?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * Whether remote execution is enabled
      */
@@ -378,15 +378,15 @@ export interface DeploymentRemoteExecution {
     /**
      * The URL for the remote API
      */
-    remoteApiUrl?: pulumi.Input<string>;
+    remoteApiUrl?: pulumi.Input<string | undefined>;
     /**
      * The bucket for task logs
      */
-    taskLogBucket?: pulumi.Input<string>;
+    taskLogBucket?: pulumi.Input<string | undefined>;
     /**
      * The URL pattern for task logs
      */
-    taskLogUrlPattern?: pulumi.Input<string>;
+    taskLogUrlPattern?: pulumi.Input<string | undefined>;
 }
 
 export interface DeploymentScalingSpec {
@@ -400,51 +400,51 @@ export interface DeploymentScalingSpecHibernationSpec {
     /**
      * Hibernation override configuration. Set to null to remove the override.
      */
-    override?: pulumi.Input<inputs.DeploymentScalingSpecHibernationSpecOverride>;
+    override?: pulumi.Input<inputs.DeploymentScalingSpecHibernationSpecOverride | undefined>;
     /**
      * List of hibernation schedules. Set to null to remove all schedules.
      */
-    schedules?: pulumi.Input<pulumi.Input<inputs.DeploymentScalingSpecHibernationSpecSchedule>[]>;
+    schedules?: pulumi.Input<pulumi.Input<inputs.DeploymentScalingSpecHibernationSpecSchedule>[] | undefined>;
 }
 
 export interface DeploymentScalingSpecHibernationSpecOverride {
-    isActive?: pulumi.Input<boolean>;
+    isActive?: pulumi.Input<boolean | undefined>;
     isHibernating: pulumi.Input<boolean>;
-    overrideUntil?: pulumi.Input<string>;
+    overrideUntil?: pulumi.Input<string | undefined>;
 }
 
 export interface DeploymentScalingSpecHibernationSpecSchedule {
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     hibernateAtCron: pulumi.Input<string>;
     isEnabled: pulumi.Input<boolean>;
     wakeAtCron: pulumi.Input<string>;
 }
 
 export interface DeploymentScalingStatus {
-    hibernationStatus?: pulumi.Input<inputs.DeploymentScalingStatusHibernationStatus>;
+    hibernationStatus?: pulumi.Input<inputs.DeploymentScalingStatusHibernationStatus | undefined>;
 }
 
 export interface DeploymentScalingStatusHibernationStatus {
-    isHibernating?: pulumi.Input<boolean>;
-    nextEventAt?: pulumi.Input<string>;
-    nextEventType?: pulumi.Input<string>;
-    reason?: pulumi.Input<string>;
+    isHibernating?: pulumi.Input<boolean | undefined>;
+    nextEventAt?: pulumi.Input<string | undefined>;
+    nextEventType?: pulumi.Input<string | undefined>;
+    reason?: pulumi.Input<string | undefined>;
 }
 
 export interface DeploymentUpdatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface DeploymentWorkerQueue {
     /**
      * Worker queue Astro machine value - required for 'STANDARD' and 'DEDICATED' deployments. Allowed values: `A5`, `A10`, `A20`, `A40`, `A60`, `A120`, `A160`.
      */
-    astroMachine?: pulumi.Input<string>;
+    astroMachine?: pulumi.Input<string | undefined>;
     /**
      * Worker queue default
      */
@@ -464,15 +464,15 @@ export interface DeploymentWorkerQueue {
     /**
      * Worker queue Node pool identifier - required for 'HYBRID' deployments
      */
-    nodePoolId?: pulumi.Input<string>;
+    nodePoolId?: pulumi.Input<string | undefined>;
     /**
      * Worker queue pod CPU
      */
-    podCpu?: pulumi.Input<string>;
+    podCpu?: pulumi.Input<string | undefined>;
     /**
      * Worker queue pod memory
      */
-    podMemory?: pulumi.Input<string>;
+    podMemory?: pulumi.Input<string | undefined>;
     /**
      * Worker queue worker concurrency
      */
@@ -480,68 +480,68 @@ export interface DeploymentWorkerQueue {
 }
 
 export interface NotificationChannelCreatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface NotificationChannelDefinition {
     /**
      * The API key for the notification channel
      */
-    apiKey?: pulumi.Input<string>;
+    apiKey?: pulumi.Input<string | undefined>;
     /**
      * The DAG ID for the notification channel
      */
-    dagId?: pulumi.Input<string>;
+    dagId?: pulumi.Input<string | undefined>;
     /**
      * The deployment API token for the notification channel
      */
-    deploymentApiToken?: pulumi.Input<string>;
+    deploymentApiToken?: pulumi.Input<string | undefined>;
     /**
      * The deployment ID for the notification channel
      */
-    deploymentId?: pulumi.Input<string>;
+    deploymentId?: pulumi.Input<string | undefined>;
     /**
      * The integration key for the notification channel
      */
-    integrationKey?: pulumi.Input<string>;
+    integrationKey?: pulumi.Input<string | undefined>;
     /**
      * The recipients for the notification channel
      */
-    recipients?: pulumi.Input<pulumi.Input<string>[]>;
+    recipients?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * The webhook URL for the notification channel
      */
-    webhookUrl?: pulumi.Input<string>;
+    webhookUrl?: pulumi.Input<string | undefined>;
 }
 
 export interface NotificationChannelUpdatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface TeamCreatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface TeamDagRole {
     /**
      * The DAG ID. Required if tag is not specified.
      */
-    dagId?: pulumi.Input<string>;
+    dagId?: pulumi.Input<string | undefined>;
     /**
      * The Deployment ID containing the DAG.
      */
@@ -553,7 +553,7 @@ export interface TeamDagRole {
     /**
      * The DAG tag. Required if dagId is not specified.
      */
-    tag?: pulumi.Input<string>;
+    tag?: pulumi.Input<string | undefined>;
 }
 
 export interface TeamDeploymentRole {
@@ -571,7 +571,7 @@ export interface TeamRolesDagRole {
     /**
      * The DAG ID. Required if tag is not specified.
      */
-    dagId?: pulumi.Input<string>;
+    dagId?: pulumi.Input<string | undefined>;
     /**
      * The Deployment ID containing the DAG.
      */
@@ -583,7 +583,7 @@ export interface TeamRolesDagRole {
     /**
      * The DAG tag. Required if dagId is not specified.
      */
-    tag?: pulumi.Input<string>;
+    tag?: pulumi.Input<string | undefined>;
 }
 
 export interface TeamRolesDeploymentRole {
@@ -609,12 +609,12 @@ export interface TeamRolesWorkspaceRole {
 }
 
 export interface TeamUpdatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface TeamWorkspaceRole {
@@ -629,28 +629,28 @@ export interface TeamWorkspaceRole {
 }
 
 export interface UserInviteInvitee {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface UserInviteInviter {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface UserRolesDagRole {
     /**
      * The DAG ID. Required if tag is not specified.
      */
-    dagId?: pulumi.Input<string>;
+    dagId?: pulumi.Input<string | undefined>;
     /**
      * The Deployment ID containing the DAG.
      */
@@ -662,7 +662,7 @@ export interface UserRolesDagRole {
     /**
      * The DAG tag. Required if dagId is not specified.
      */
-    tag?: pulumi.Input<string>;
+    tag?: pulumi.Input<string | undefined>;
 }
 
 export interface UserRolesDeploymentRole {
@@ -688,19 +688,19 @@ export interface UserRolesWorkspaceRole {
 }
 
 export interface WorkspaceCreatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }
 
 export interface WorkspaceUpdatedBy {
-    apiTokenName?: pulumi.Input<string>;
-    avatarUrl?: pulumi.Input<string>;
-    fullName?: pulumi.Input<string>;
-    id?: pulumi.Input<string>;
-    subjectType?: pulumi.Input<string>;
-    username?: pulumi.Input<string>;
+    apiTokenName?: pulumi.Input<string | undefined>;
+    avatarUrl?: pulumi.Input<string | undefined>;
+    fullName?: pulumi.Input<string | undefined>;
+    id?: pulumi.Input<string | undefined>;
+    subjectType?: pulumi.Input<string | undefined>;
+    username?: pulumi.Input<string | undefined>;
 }

--- a/sdk/nodejs/userInvite.ts
+++ b/sdk/nodejs/userInvite.ts
@@ -126,31 +126,31 @@ export interface UserInviteState {
     /**
      * The email address of the user being invited
      */
-    email?: pulumi.Input<string>;
+    email?: pulumi.Input<string | undefined>;
     /**
      * The expiration date of the invite
      */
-    expiresAt?: pulumi.Input<string>;
+    expiresAt?: pulumi.Input<string | undefined>;
     /**
      * The ID of the invite
      */
-    inviteId?: pulumi.Input<string>;
+    inviteId?: pulumi.Input<string | undefined>;
     /**
      * The profile of the invitee
      */
-    invitee?: pulumi.Input<inputs.UserInviteInvitee>;
+    invitee?: pulumi.Input<inputs.UserInviteInvitee | undefined>;
     /**
      * The profile of the inviter
      */
-    inviter?: pulumi.Input<inputs.UserInviteInviter>;
+    inviter?: pulumi.Input<inputs.UserInviteInviter | undefined>;
     /**
      * The Organization role to assign to the user
      */
-    role?: pulumi.Input<string>;
+    role?: pulumi.Input<string | undefined>;
     /**
      * The ID of the user
      */
-    userId?: pulumi.Input<string>;
+    userId?: pulumi.Input<string | undefined>;
 }
 
 /**

--- a/sdk/nodejs/userRoles.ts
+++ b/sdk/nodejs/userRoles.ts
@@ -102,23 +102,23 @@ export interface UserRolesState {
     /**
      * The DAG roles to assign to the user. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dagRoles` must also have a corresponding entry in `deploymentRoles` (e.g. with `DEPLOYMENT_ACCESSOR` role).
      */
-    dagRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesDagRole>[]>;
+    dagRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesDagRole>[] | undefined>;
     /**
      * The roles to assign to the deployments. Each `deploymentId` must belong to a workspace that also appears in `workspaceRoles`. Required for any deployment referenced in `dagRoles`.
      */
-    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesDeploymentRole>[]>;
+    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesDeploymentRole>[] | undefined>;
     /**
      * The role to assign to the organization
      */
-    organizationRole?: pulumi.Input<string>;
+    organizationRole?: pulumi.Input<string | undefined>;
     /**
      * The ID of the user to assign the roles to
      */
-    userId?: pulumi.Input<string>;
+    userId?: pulumi.Input<string | undefined>;
     /**
      * The roles to assign to the workspaces. When you set `deploymentRoles` or `dagRoles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
      */
-    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesWorkspaceRole>[]>;
+    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesWorkspaceRole>[] | undefined>;
 }
 
 /**
@@ -128,11 +128,11 @@ export interface UserRolesArgs {
     /**
      * The DAG roles to assign to the user. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dagRoles` must also have a corresponding entry in `deploymentRoles` (e.g. with `DEPLOYMENT_ACCESSOR` role).
      */
-    dagRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesDagRole>[]>;
+    dagRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesDagRole>[] | undefined>;
     /**
      * The roles to assign to the deployments. Each `deploymentId` must belong to a workspace that also appears in `workspaceRoles`. Required for any deployment referenced in `dagRoles`.
      */
-    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesDeploymentRole>[]>;
+    deploymentRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesDeploymentRole>[] | undefined>;
     /**
      * The role to assign to the organization
      */
@@ -144,5 +144,5 @@ export interface UserRolesArgs {
     /**
      * The roles to assign to the workspaces. When you set `deploymentRoles` or `dagRoles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
      */
-    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesWorkspaceRole>[]>;
+    workspaceRoles?: pulumi.Input<pulumi.Input<inputs.UserRolesWorkspaceRole>[] | undefined>;
 }

--- a/sdk/nodejs/workspace.ts
+++ b/sdk/nodejs/workspace.ts
@@ -114,31 +114,31 @@ export interface WorkspaceState {
     /**
      * Whether new Deployments enforce CI/CD deploys by default
      */
-    cicdEnforcedDefault?: pulumi.Input<boolean>;
+    cicdEnforcedDefault?: pulumi.Input<boolean | undefined>;
     /**
      * Workspace creation timestamp
      */
-    createdAt?: pulumi.Input<string>;
+    createdAt?: pulumi.Input<string | undefined>;
     /**
      * Workspace creator
      */
-    createdBy?: pulumi.Input<inputs.WorkspaceCreatedBy>;
+    createdBy?: pulumi.Input<inputs.WorkspaceCreatedBy | undefined>;
     /**
      * Workspace description
      */
-    description?: pulumi.Input<string>;
+    description?: pulumi.Input<string | undefined>;
     /**
      * Workspace name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * Workspace last updated timestamp
      */
-    updatedAt?: pulumi.Input<string>;
+    updatedAt?: pulumi.Input<string | undefined>;
     /**
      * Workspace updater
      */
-    updatedBy?: pulumi.Input<inputs.WorkspaceUpdatedBy>;
+    updatedBy?: pulumi.Input<inputs.WorkspaceUpdatedBy | undefined>;
 }
 
 /**
@@ -156,5 +156,5 @@ export interface WorkspaceArgs {
     /**
      * Workspace name
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/sdk/python/pulumi_astronomer/_inputs.py
+++ b/sdk/python/pulumi_astronomer/_inputs.py
@@ -114,22 +114,22 @@ __all__ = [
 ]
 
 class AlertCreatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class AlertCreatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -145,56 +145,56 @@ class AlertCreatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
@@ -219,39 +219,39 @@ class AlertNotificationChannelArgsDict(TypedDict):
     """
     The notification channel's type
     """
-    created_at: NotRequired[pulumi.Input[_builtins.str]]
+    created_at: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Notification Channel creation timestamp
     """
-    created_by: NotRequired[pulumi.Input['AlertNotificationChannelCreatedByArgsDict']]
+    created_by: NotRequired[pulumi.Input[Optional['AlertNotificationChannelCreatedByArgs']]]
     """
     Notification Channel creator
     """
-    deployment_id: NotRequired[pulumi.Input[_builtins.str]]
+    deployment_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The deployment ID the notification channel is scoped to
     """
-    entity_name: NotRequired[pulumi.Input[_builtins.str]]
+    entity_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The name of the entity the notification channel is scoped to
     """
-    id: NotRequired[pulumi.Input[_builtins.str]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The notification channel's ID
     """
-    is_shared: NotRequired[pulumi.Input[_builtins.bool]]
+    is_shared: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
     """
     When entity type is scoped to ORGANIZATION or WORKSPACE, this determines if child entities can access this notification channel.
     """
-    updated_at: NotRequired[pulumi.Input[_builtins.str]]
+    updated_at: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Notification Channel last updated timestamp
     """
-    updated_by: NotRequired[pulumi.Input['AlertNotificationChannelUpdatedByArgsDict']]
+    updated_by: NotRequired[pulumi.Input[Optional['AlertNotificationChannelUpdatedByArgs']]]
     """
     Notification Channel updater
     """
-    workspace_id: NotRequired[pulumi.Input[_builtins.str]]
+    workspace_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The workspace ID the notification channel is scoped to
     """
@@ -264,15 +264,15 @@ class AlertNotificationChannelArgs:
                  entity_type: pulumi.Input[_builtins.str],
                  name: pulumi.Input[_builtins.str],
                  type: pulumi.Input[_builtins.str],
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_by: Optional[pulumi.Input['AlertNotificationChannelCreatedByArgs']] = None,
-                 deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_shared: Optional[pulumi.Input[_builtins.bool]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_by: Optional[pulumi.Input['AlertNotificationChannelUpdatedByArgs']] = None,
-                 workspace_id: Optional[pulumi.Input[_builtins.str]] = None):
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_by: pulumi.Input[Optional['AlertNotificationChannelCreatedByArgs']] = None,
+                 deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_shared: pulumi.Input[Optional[_builtins.bool]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_by: pulumi.Input[Optional['AlertNotificationChannelUpdatedByArgs']] = None,
+                 workspace_id: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input['AlertNotificationChannelDefinitionArgs'] definition: The notification channel's definition
         :param pulumi.Input[_builtins.str] entity_id: The entity ID the notification channel is scoped to
@@ -375,130 +375,130 @@ class AlertNotificationChannelArgs:
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Notification Channel creation timestamp
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter(name="createdBy")
-    def created_by(self) -> Optional[pulumi.Input['AlertNotificationChannelCreatedByArgs']]:
+    def created_by(self) -> pulumi.Input[Optional['AlertNotificationChannelCreatedByArgs']]:
         """
         Notification Channel creator
         """
         return pulumi.get(self, "created_by")
 
     @created_by.setter
-    def created_by(self, value: Optional[pulumi.Input['AlertNotificationChannelCreatedByArgs']]):
+    def created_by(self, value: pulumi.Input[Optional['AlertNotificationChannelCreatedByArgs']]):
         pulumi.set(self, "created_by", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentId")
-    def deployment_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def deployment_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The deployment ID the notification channel is scoped to
         """
         return pulumi.get(self, "deployment_id")
 
     @deployment_id.setter
-    def deployment_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def deployment_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "deployment_id", value)
 
     @_builtins.property
     @pulumi.getter(name="entityName")
-    def entity_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def entity_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The name of the entity the notification channel is scoped to
         """
         return pulumi.get(self, "entity_name")
 
     @entity_name.setter
-    def entity_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def entity_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "entity_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The notification channel's ID
         """
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="isShared")
-    def is_shared(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_shared(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         When entity type is scoped to ORGANIZATION or WORKSPACE, this determines if child entities can access this notification channel.
         """
         return pulumi.get(self, "is_shared")
 
     @is_shared.setter
-    def is_shared(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_shared(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_shared", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Notification Channel last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedBy")
-    def updated_by(self) -> Optional[pulumi.Input['AlertNotificationChannelUpdatedByArgs']]:
+    def updated_by(self) -> pulumi.Input[Optional['AlertNotificationChannelUpdatedByArgs']]:
         """
         Notification Channel updater
         """
         return pulumi.get(self, "updated_by")
 
     @updated_by.setter
-    def updated_by(self, value: Optional[pulumi.Input['AlertNotificationChannelUpdatedByArgs']]):
+    def updated_by(self, value: pulumi.Input[Optional['AlertNotificationChannelUpdatedByArgs']]):
         pulumi.set(self, "updated_by", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def workspace_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The workspace ID the notification channel is scoped to
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def workspace_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "workspace_id", value)
 
 
 class AlertNotificationChannelCreatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class AlertNotificationChannelCreatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -514,85 +514,85 @@ class AlertNotificationChannelCreatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
 class AlertNotificationChannelDefinitionArgsDict(TypedDict):
-    api_key: NotRequired[pulumi.Input[_builtins.str]]
+    api_key: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The API key for the notification channel
     """
-    dag_id: NotRequired[pulumi.Input[_builtins.str]]
+    dag_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The DAG ID for the notification channel
     """
-    deployment_api_token: NotRequired[pulumi.Input[_builtins.str]]
+    deployment_api_token: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The deployment API token for the notification channel
     """
-    deployment_id: NotRequired[pulumi.Input[_builtins.str]]
+    deployment_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The deployment ID for the notification channel
     """
-    integration_key: NotRequired[pulumi.Input[_builtins.str]]
+    integration_key: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The integration key for the notification channel
     """
-    recipients: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    recipients: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]]
     """
     The recipients for the notification channel
     """
-    webhook_url: NotRequired[pulumi.Input[_builtins.str]]
+    webhook_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The webhook URL for the notification channel
     """
@@ -600,13 +600,13 @@ class AlertNotificationChannelDefinitionArgsDict(TypedDict):
 @pulumi.input_type
 class AlertNotificationChannelDefinitionArgs:
     def __init__(__self__, *,
-                 api_key: Optional[pulumi.Input[_builtins.str]] = None,
-                 dag_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 deployment_api_token: Optional[pulumi.Input[_builtins.str]] = None,
-                 deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 integration_key: Optional[pulumi.Input[_builtins.str]] = None,
-                 recipients: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 webhook_url: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_key: pulumi.Input[Optional[_builtins.str]] = None,
+                 dag_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 deployment_api_token: pulumi.Input[Optional[_builtins.str]] = None,
+                 deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 integration_key: pulumi.Input[Optional[_builtins.str]] = None,
+                 recipients: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 webhook_url: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] api_key: The API key for the notification channel
         :param pulumi.Input[_builtins.str] dag_id: The DAG ID for the notification channel
@@ -633,106 +633,106 @@ class AlertNotificationChannelDefinitionArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiKey")
-    def api_key(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_key(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The API key for the notification channel
         """
         return pulumi.get(self, "api_key")
 
     @api_key.setter
-    def api_key(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_key(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_key", value)
 
     @_builtins.property
     @pulumi.getter(name="dagId")
-    def dag_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dag_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The DAG ID for the notification channel
         """
         return pulumi.get(self, "dag_id")
 
     @dag_id.setter
-    def dag_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dag_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dag_id", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentApiToken")
-    def deployment_api_token(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def deployment_api_token(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The deployment API token for the notification channel
         """
         return pulumi.get(self, "deployment_api_token")
 
     @deployment_api_token.setter
-    def deployment_api_token(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def deployment_api_token(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "deployment_api_token", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentId")
-    def deployment_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def deployment_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The deployment ID for the notification channel
         """
         return pulumi.get(self, "deployment_id")
 
     @deployment_id.setter
-    def deployment_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def deployment_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "deployment_id", value)
 
     @_builtins.property
     @pulumi.getter(name="integrationKey")
-    def integration_key(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def integration_key(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The integration key for the notification channel
         """
         return pulumi.get(self, "integration_key")
 
     @integration_key.setter
-    def integration_key(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def integration_key(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "integration_key", value)
 
     @_builtins.property
     @pulumi.getter
-    def recipients(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def recipients(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The recipients for the notification channel
         """
         return pulumi.get(self, "recipients")
 
     @recipients.setter
-    def recipients(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def recipients(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "recipients", value)
 
     @_builtins.property
     @pulumi.getter(name="webhookUrl")
-    def webhook_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def webhook_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The webhook URL for the notification channel
         """
         return pulumi.get(self, "webhook_url")
 
     @webhook_url.setter
-    def webhook_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def webhook_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "webhook_url", value)
 
 
 class AlertNotificationChannelUpdatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class AlertNotificationChannelUpdatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -748,56 +748,56 @@ class AlertNotificationChannelUpdatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
@@ -919,23 +919,23 @@ class AlertRulesPropertiesArgsDict(TypedDict):
     """
     The ID of the deployment for the alert rule
     """
-    dag_deadline: NotRequired[pulumi.Input[_builtins.str]]
+    dag_deadline: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The deadline for the DAG in HH:MM 24-hour UTC format
     """
-    dag_duration_seconds: NotRequired[pulumi.Input[_builtins.int]]
+    dag_duration_seconds: NotRequired[pulumi.Input[Optional[_builtins.int]]]
     """
     The duration of the DAG in seconds (minimum 60)
     """
-    days_of_weeks: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    days_of_weeks: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]]
     """
     The days of the week for the timeliness rule
     """
-    look_back_period_seconds: NotRequired[pulumi.Input[_builtins.int]]
+    look_back_period_seconds: NotRequired[pulumi.Input[Optional[_builtins.int]]]
     """
     The look-back period in seconds (minimum 60)
     """
-    task_duration_seconds: NotRequired[pulumi.Input[_builtins.int]]
+    task_duration_seconds: NotRequired[pulumi.Input[Optional[_builtins.int]]]
     """
     The duration of the Task in seconds (minimum 60)
     """
@@ -944,11 +944,11 @@ class AlertRulesPropertiesArgsDict(TypedDict):
 class AlertRulesPropertiesArgs:
     def __init__(__self__, *,
                  deployment_id: pulumi.Input[_builtins.str],
-                 dag_deadline: Optional[pulumi.Input[_builtins.str]] = None,
-                 dag_duration_seconds: Optional[pulumi.Input[_builtins.int]] = None,
-                 days_of_weeks: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 look_back_period_seconds: Optional[pulumi.Input[_builtins.int]] = None,
-                 task_duration_seconds: Optional[pulumi.Input[_builtins.int]] = None):
+                 dag_deadline: pulumi.Input[Optional[_builtins.str]] = None,
+                 dag_duration_seconds: pulumi.Input[Optional[_builtins.int]] = None,
+                 days_of_weeks: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 look_back_period_seconds: pulumi.Input[Optional[_builtins.int]] = None,
+                 task_duration_seconds: pulumi.Input[Optional[_builtins.int]] = None):
         """
         :param pulumi.Input[_builtins.str] deployment_id: The ID of the deployment for the alert rule
         :param pulumi.Input[_builtins.str] dag_deadline: The deadline for the DAG in HH:MM 24-hour UTC format
@@ -983,82 +983,82 @@ class AlertRulesPropertiesArgs:
 
     @_builtins.property
     @pulumi.getter(name="dagDeadline")
-    def dag_deadline(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dag_deadline(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The deadline for the DAG in HH:MM 24-hour UTC format
         """
         return pulumi.get(self, "dag_deadline")
 
     @dag_deadline.setter
-    def dag_deadline(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dag_deadline(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dag_deadline", value)
 
     @_builtins.property
     @pulumi.getter(name="dagDurationSeconds")
-    def dag_duration_seconds(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def dag_duration_seconds(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         The duration of the DAG in seconds (minimum 60)
         """
         return pulumi.get(self, "dag_duration_seconds")
 
     @dag_duration_seconds.setter
-    def dag_duration_seconds(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def dag_duration_seconds(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "dag_duration_seconds", value)
 
     @_builtins.property
     @pulumi.getter(name="daysOfWeeks")
-    def days_of_weeks(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def days_of_weeks(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The days of the week for the timeliness rule
         """
         return pulumi.get(self, "days_of_weeks")
 
     @days_of_weeks.setter
-    def days_of_weeks(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def days_of_weeks(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "days_of_weeks", value)
 
     @_builtins.property
     @pulumi.getter(name="lookBackPeriodSeconds")
-    def look_back_period_seconds(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def look_back_period_seconds(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         The look-back period in seconds (minimum 60)
         """
         return pulumi.get(self, "look_back_period_seconds")
 
     @look_back_period_seconds.setter
-    def look_back_period_seconds(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def look_back_period_seconds(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "look_back_period_seconds", value)
 
     @_builtins.property
     @pulumi.getter(name="taskDurationSeconds")
-    def task_duration_seconds(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def task_duration_seconds(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         The duration of the Task in seconds (minimum 60)
         """
         return pulumi.get(self, "task_duration_seconds")
 
     @task_duration_seconds.setter
-    def task_duration_seconds(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def task_duration_seconds(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "task_duration_seconds", value)
 
 
 class AlertUpdatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class AlertUpdatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -1074,76 +1074,76 @@ class AlertUpdatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
 class ApiTokenCreatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class ApiTokenCreatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -1159,56 +1159,56 @@ class ApiTokenCreatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
@@ -1225,7 +1225,7 @@ class ApiTokenRoleArgsDict(TypedDict):
     """
     The role to assign to the entity
     """
-    deployment_id: NotRequired[pulumi.Input[_builtins.str]]
+    deployment_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The Deployment ID. Required for DAG and TAG entity types.
     """
@@ -1236,7 +1236,7 @@ class ApiTokenRoleArgs:
                  entity_id: pulumi.Input[_builtins.str],
                  entity_type: pulumi.Input[_builtins.str],
                  role: pulumi.Input[_builtins.str],
-                 deployment_id: Optional[pulumi.Input[_builtins.str]] = None):
+                 deployment_id: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] entity_id: The ID of the entity to assign the role to. For DAG entity type, this is the dag_id. For TAG entity type, this is the tag value.
         :param pulumi.Input[_builtins.str] entity_type: The type of entity to assign the role to
@@ -1287,34 +1287,34 @@ class ApiTokenRoleArgs:
 
     @_builtins.property
     @pulumi.getter(name="deploymentId")
-    def deployment_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def deployment_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The Deployment ID. Required for DAG and TAG entity types.
         """
         return pulumi.get(self, "deployment_id")
 
     @deployment_id.setter
-    def deployment_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def deployment_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "deployment_id", value)
 
 
 class ApiTokenUpdatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class ApiTokenUpdatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -1330,65 +1330,65 @@ class ApiTokenUpdatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
 class ClusterHealthStatusArgsDict(TypedDict):
-    details: NotRequired[pulumi.Input[Sequence[pulumi.Input['ClusterHealthStatusDetailArgsDict']]]]
+    details: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['ClusterHealthStatusDetailArgs']]]]]
     """
     Cluster health status details
     """
-    value: NotRequired[pulumi.Input[_builtins.str]]
+    value: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Cluster health status value
     """
@@ -1396,8 +1396,8 @@ class ClusterHealthStatusArgsDict(TypedDict):
 @pulumi.input_type
 class ClusterHealthStatusArgs:
     def __init__(__self__, *,
-                 details: Optional[pulumi.Input[Sequence[pulumi.Input['ClusterHealthStatusDetailArgs']]]] = None,
-                 value: Optional[pulumi.Input[_builtins.str]] = None):
+                 details: pulumi.Input[Optional[Sequence[pulumi.Input['ClusterHealthStatusDetailArgs']]]] = None,
+                 value: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[Sequence[pulumi.Input['ClusterHealthStatusDetailArgs']]] details: Cluster health status details
         :param pulumi.Input[_builtins.str] value: Cluster health status value
@@ -1409,39 +1409,39 @@ class ClusterHealthStatusArgs:
 
     @_builtins.property
     @pulumi.getter
-    def details(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['ClusterHealthStatusDetailArgs']]]]:
+    def details(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['ClusterHealthStatusDetailArgs']]]]:
         """
         Cluster health status details
         """
         return pulumi.get(self, "details")
 
     @details.setter
-    def details(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ClusterHealthStatusDetailArgs']]]]):
+    def details(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['ClusterHealthStatusDetailArgs']]]]):
         pulumi.set(self, "details", value)
 
     @_builtins.property
     @pulumi.getter
-    def value(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def value(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster health status value
         """
         return pulumi.get(self, "value")
 
     @value.setter
-    def value(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def value(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "value", value)
 
 
 class ClusterHealthStatusDetailArgsDict(TypedDict):
-    code: NotRequired[pulumi.Input[_builtins.str]]
+    code: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Cluster health status detail code
     """
-    description: NotRequired[pulumi.Input[_builtins.str]]
+    description: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Cluster health status detail description
     """
-    severity: NotRequired[pulumi.Input[_builtins.str]]
+    severity: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Cluster health status detail severity
     """
@@ -1449,9 +1449,9 @@ class ClusterHealthStatusDetailArgsDict(TypedDict):
 @pulumi.input_type
 class ClusterHealthStatusDetailArgs:
     def __init__(__self__, *,
-                 code: Optional[pulumi.Input[_builtins.str]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 severity: Optional[pulumi.Input[_builtins.str]] = None):
+                 code: pulumi.Input[Optional[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 severity: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] code: Cluster health status detail code
         :param pulumi.Input[_builtins.str] description: Cluster health status detail description
@@ -1466,51 +1466,51 @@ class ClusterHealthStatusDetailArgs:
 
     @_builtins.property
     @pulumi.getter
-    def code(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def code(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster health status detail code
         """
         return pulumi.get(self, "code")
 
     @code.setter
-    def code(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def code(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "code", value)
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster health status detail description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter
-    def severity(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def severity(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster health status detail severity
         """
         return pulumi.get(self, "severity")
 
     @severity.setter
-    def severity(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def severity(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "severity", value)
 
 
 class ClusterMetadataArgsDict(TypedDict):
-    external_ips: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    external_ips: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]]
     """
     Cluster external IPs
     """
-    kube_dns_ip: NotRequired[pulumi.Input[_builtins.str]]
+    kube_dns_ip: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Cluster kube DNS IP
     """
-    oidc_issuer_url: NotRequired[pulumi.Input[_builtins.str]]
+    oidc_issuer_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Cluster OIDC issuer URL
     """
@@ -1518,9 +1518,9 @@ class ClusterMetadataArgsDict(TypedDict):
 @pulumi.input_type
 class ClusterMetadataArgs:
     def __init__(__self__, *,
-                 external_ips: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 kube_dns_ip: Optional[pulumi.Input[_builtins.str]] = None,
-                 oidc_issuer_url: Optional[pulumi.Input[_builtins.str]] = None):
+                 external_ips: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 kube_dns_ip: pulumi.Input[Optional[_builtins.str]] = None,
+                 oidc_issuer_url: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] external_ips: Cluster external IPs
         :param pulumi.Input[_builtins.str] kube_dns_ip: Cluster kube DNS IP
@@ -1535,79 +1535,79 @@ class ClusterMetadataArgs:
 
     @_builtins.property
     @pulumi.getter(name="externalIps")
-    def external_ips(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def external_ips(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         Cluster external IPs
         """
         return pulumi.get(self, "external_ips")
 
     @external_ips.setter
-    def external_ips(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def external_ips(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "external_ips", value)
 
     @_builtins.property
     @pulumi.getter(name="kubeDnsIp")
-    def kube_dns_ip(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def kube_dns_ip(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster kube DNS IP
         """
         return pulumi.get(self, "kube_dns_ip")
 
     @kube_dns_ip.setter
-    def kube_dns_ip(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def kube_dns_ip(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "kube_dns_ip", value)
 
     @_builtins.property
     @pulumi.getter(name="oidcIssuerUrl")
-    def oidc_issuer_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def oidc_issuer_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster OIDC issuer URL
         """
         return pulumi.get(self, "oidc_issuer_url")
 
     @oidc_issuer_url.setter
-    def oidc_issuer_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def oidc_issuer_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "oidc_issuer_url", value)
 
 
 class ClusterNodePoolArgsDict(TypedDict):
-    cloud_provider: NotRequired[pulumi.Input[_builtins.str]]
+    cloud_provider: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Node pool cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
     """
-    cluster_id: NotRequired[pulumi.Input[_builtins.str]]
+    cluster_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Node pool cluster identifier
     """
-    created_at: NotRequired[pulumi.Input[_builtins.str]]
+    created_at: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Node pool creation timestamp
     """
-    id: NotRequired[pulumi.Input[_builtins.str]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Node pool identifier
     """
-    is_default: NotRequired[pulumi.Input[_builtins.bool]]
+    is_default: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
     """
     Whether the node pool is the default node pool of the cluster
     """
-    max_node_count: NotRequired[pulumi.Input[_builtins.int]]
+    max_node_count: NotRequired[pulumi.Input[Optional[_builtins.int]]]
     """
     Node pool maximum node count
     """
-    name: NotRequired[pulumi.Input[_builtins.str]]
+    name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Node pool name
     """
-    node_instance_type: NotRequired[pulumi.Input[_builtins.str]]
+    node_instance_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Node pool node instance type
     """
-    supported_astro_machines: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    supported_astro_machines: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]]
     """
     Node pool supported Astro machines
     """
-    updated_at: NotRequired[pulumi.Input[_builtins.str]]
+    updated_at: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Node pool last updated timestamp
     """
@@ -1615,16 +1615,16 @@ class ClusterNodePoolArgsDict(TypedDict):
 @pulumi.input_type
 class ClusterNodePoolArgs:
     def __init__(__self__, *,
-                 cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-                 cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_default: Optional[pulumi.Input[_builtins.bool]] = None,
-                 max_node_count: Optional[pulumi.Input[_builtins.int]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 node_instance_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 supported_astro_machines: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None):
+                 cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+                 cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_default: pulumi.Input[Optional[_builtins.bool]] = None,
+                 max_node_count: pulumi.Input[Optional[_builtins.int]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 node_instance_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 supported_astro_machines: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] cloud_provider: Node pool cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
         :param pulumi.Input[_builtins.str] cluster_id: Node pool cluster identifier
@@ -1660,135 +1660,135 @@ class ClusterNodePoolArgs:
 
     @_builtins.property
     @pulumi.getter(name="cloudProvider")
-    def cloud_provider(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def cloud_provider(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Node pool cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
         """
         return pulumi.get(self, "cloud_provider")
 
     @cloud_provider.setter
-    def cloud_provider(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def cloud_provider(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "cloud_provider", value)
 
     @_builtins.property
     @pulumi.getter(name="clusterId")
-    def cluster_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def cluster_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Node pool cluster identifier
         """
         return pulumi.get(self, "cluster_id")
 
     @cluster_id.setter
-    def cluster_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def cluster_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "cluster_id", value)
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Node pool creation timestamp
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Node pool identifier
         """
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="isDefault")
-    def is_default(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_default(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether the node pool is the default node pool of the cluster
         """
         return pulumi.get(self, "is_default")
 
     @is_default.setter
-    def is_default(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_default(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_default", value)
 
     @_builtins.property
     @pulumi.getter(name="maxNodeCount")
-    def max_node_count(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def max_node_count(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         Node pool maximum node count
         """
         return pulumi.get(self, "max_node_count")
 
     @max_node_count.setter
-    def max_node_count(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def max_node_count(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "max_node_count", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Node pool name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter(name="nodeInstanceType")
-    def node_instance_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def node_instance_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Node pool node instance type
         """
         return pulumi.get(self, "node_instance_type")
 
     @node_instance_type.setter
-    def node_instance_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def node_instance_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "node_instance_type", value)
 
     @_builtins.property
     @pulumi.getter(name="supportedAstroMachines")
-    def supported_astro_machines(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def supported_astro_machines(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         Node pool supported Astro machines
         """
         return pulumi.get(self, "supported_astro_machines")
 
     @supported_astro_machines.setter
-    def supported_astro_machines(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def supported_astro_machines(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "supported_astro_machines", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Node pool last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
 
 class ClusterTimeoutsArgsDict(TypedDict):
-    create: NotRequired[pulumi.Input[_builtins.str]]
+    create: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
     """
-    delete: NotRequired[pulumi.Input[_builtins.str]]
+    delete: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
     """
-    update: NotRequired[pulumi.Input[_builtins.str]]
+    update: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
     """
@@ -1796,9 +1796,9 @@ class ClusterTimeoutsArgsDict(TypedDict):
 @pulumi.input_type
 class ClusterTimeoutsArgs:
     def __init__(__self__, *,
-                 create: Optional[pulumi.Input[_builtins.str]] = None,
-                 delete: Optional[pulumi.Input[_builtins.str]] = None,
-                 update: Optional[pulumi.Input[_builtins.str]] = None):
+                 create: pulumi.Input[Optional[_builtins.str]] = None,
+                 delete: pulumi.Input[Optional[_builtins.str]] = None,
+                 update: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] create: A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
         :param pulumi.Input[_builtins.str] delete: A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
@@ -1813,58 +1813,58 @@ class ClusterTimeoutsArgs:
 
     @_builtins.property
     @pulumi.getter
-    def create(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def create(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
         """
         return pulumi.get(self, "create")
 
     @create.setter
-    def create(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def create(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "create", value)
 
     @_builtins.property
     @pulumi.getter
-    def delete(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def delete(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
         """
         return pulumi.get(self, "delete")
 
     @delete.setter
-    def delete(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def delete(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "delete", value)
 
     @_builtins.property
     @pulumi.getter
-    def update(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def update(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
         """
         return pulumi.get(self, "update")
 
     @update.setter
-    def update(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def update(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "update", value)
 
 
 class CustomRoleCreatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class CustomRoleCreatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -1880,76 +1880,76 @@ class CustomRoleCreatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
 class CustomRoleUpdatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class CustomRoleUpdatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -1965,76 +1965,76 @@ class CustomRoleUpdatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
 class DeploymentCreatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class DeploymentCreatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -2050,56 +2050,56 @@ class DeploymentCreatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
@@ -2112,11 +2112,11 @@ class DeploymentEnvironmentVariableArgsDict(TypedDict):
     """
     Environment variable key
     """
-    updated_at: NotRequired[pulumi.Input[_builtins.str]]
+    updated_at: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Environment variable last updated timestamp
     """
-    value: NotRequired[pulumi.Input[_builtins.str]]
+    value: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Environment variable value
     """
@@ -2126,8 +2126,8 @@ class DeploymentEnvironmentVariableArgs:
     def __init__(__self__, *,
                  is_secret: pulumi.Input[_builtins.bool],
                  key: pulumi.Input[_builtins.str],
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 value: Optional[pulumi.Input[_builtins.str]] = None):
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 value: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.bool] is_secret: Whether Environment variable is a secret
         :param pulumi.Input[_builtins.str] key: Environment variable key
@@ -2167,26 +2167,26 @@ class DeploymentEnvironmentVariableArgs:
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Environment variable last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter
-    def value(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def value(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Environment variable value
         """
         return pulumi.get(self, "value")
 
     @value.setter
-    def value(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def value(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "value", value)
 
 
@@ -2195,19 +2195,19 @@ class DeploymentRemoteExecutionArgsDict(TypedDict):
     """
     Whether remote execution is enabled
     """
-    allowed_ip_address_ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    allowed_ip_address_ranges: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]]
     """
     The allowed IP address ranges for remote execution
     """
-    remote_api_url: NotRequired[pulumi.Input[_builtins.str]]
+    remote_api_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The URL for the remote API
     """
-    task_log_bucket: NotRequired[pulumi.Input[_builtins.str]]
+    task_log_bucket: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The bucket for task logs
     """
-    task_log_url_pattern: NotRequired[pulumi.Input[_builtins.str]]
+    task_log_url_pattern: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The URL pattern for task logs
     """
@@ -2216,10 +2216,10 @@ class DeploymentRemoteExecutionArgsDict(TypedDict):
 class DeploymentRemoteExecutionArgs:
     def __init__(__self__, *,
                  enabled: pulumi.Input[_builtins.bool],
-                 allowed_ip_address_ranges: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 remote_api_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 task_log_bucket: Optional[pulumi.Input[_builtins.str]] = None,
-                 task_log_url_pattern: Optional[pulumi.Input[_builtins.str]] = None):
+                 allowed_ip_address_ranges: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 remote_api_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 task_log_bucket: pulumi.Input[Optional[_builtins.str]] = None,
+                 task_log_url_pattern: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.bool] enabled: Whether remote execution is enabled
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] allowed_ip_address_ranges: The allowed IP address ranges for remote execution
@@ -2251,50 +2251,50 @@ class DeploymentRemoteExecutionArgs:
 
     @_builtins.property
     @pulumi.getter(name="allowedIpAddressRanges")
-    def allowed_ip_address_ranges(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def allowed_ip_address_ranges(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The allowed IP address ranges for remote execution
         """
         return pulumi.get(self, "allowed_ip_address_ranges")
 
     @allowed_ip_address_ranges.setter
-    def allowed_ip_address_ranges(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def allowed_ip_address_ranges(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "allowed_ip_address_ranges", value)
 
     @_builtins.property
     @pulumi.getter(name="remoteApiUrl")
-    def remote_api_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def remote_api_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The URL for the remote API
         """
         return pulumi.get(self, "remote_api_url")
 
     @remote_api_url.setter
-    def remote_api_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def remote_api_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "remote_api_url", value)
 
     @_builtins.property
     @pulumi.getter(name="taskLogBucket")
-    def task_log_bucket(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def task_log_bucket(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The bucket for task logs
         """
         return pulumi.get(self, "task_log_bucket")
 
     @task_log_bucket.setter
-    def task_log_bucket(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def task_log_bucket(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "task_log_bucket", value)
 
     @_builtins.property
     @pulumi.getter(name="taskLogUrlPattern")
-    def task_log_url_pattern(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def task_log_url_pattern(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The URL pattern for task logs
         """
         return pulumi.get(self, "task_log_url_pattern")
 
     @task_log_url_pattern.setter
-    def task_log_url_pattern(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def task_log_url_pattern(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "task_log_url_pattern", value)
 
 
@@ -2327,11 +2327,11 @@ class DeploymentScalingSpecArgs:
 
 
 class DeploymentScalingSpecHibernationSpecArgsDict(TypedDict):
-    override: NotRequired[pulumi.Input['DeploymentScalingSpecHibernationSpecOverrideArgsDict']]
+    override: NotRequired[pulumi.Input[Optional['DeploymentScalingSpecHibernationSpecOverrideArgs']]]
     """
     Hibernation override configuration. Set to null to remove the override.
     """
-    schedules: NotRequired[pulumi.Input[Sequence[pulumi.Input['DeploymentScalingSpecHibernationSpecScheduleArgsDict']]]]
+    schedules: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentScalingSpecHibernationSpecScheduleArgs']]]]]
     """
     List of hibernation schedules. Set to null to remove all schedules.
     """
@@ -2339,8 +2339,8 @@ class DeploymentScalingSpecHibernationSpecArgsDict(TypedDict):
 @pulumi.input_type
 class DeploymentScalingSpecHibernationSpecArgs:
     def __init__(__self__, *,
-                 override: Optional[pulumi.Input['DeploymentScalingSpecHibernationSpecOverrideArgs']] = None,
-                 schedules: Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentScalingSpecHibernationSpecScheduleArgs']]]] = None):
+                 override: pulumi.Input[Optional['DeploymentScalingSpecHibernationSpecOverrideArgs']] = None,
+                 schedules: pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentScalingSpecHibernationSpecScheduleArgs']]]] = None):
         """
         :param pulumi.Input['DeploymentScalingSpecHibernationSpecOverrideArgs'] override: Hibernation override configuration. Set to null to remove the override.
         :param pulumi.Input[Sequence[pulumi.Input['DeploymentScalingSpecHibernationSpecScheduleArgs']]] schedules: List of hibernation schedules. Set to null to remove all schedules.
@@ -2352,40 +2352,40 @@ class DeploymentScalingSpecHibernationSpecArgs:
 
     @_builtins.property
     @pulumi.getter
-    def override(self) -> Optional[pulumi.Input['DeploymentScalingSpecHibernationSpecOverrideArgs']]:
+    def override(self) -> pulumi.Input[Optional['DeploymentScalingSpecHibernationSpecOverrideArgs']]:
         """
         Hibernation override configuration. Set to null to remove the override.
         """
         return pulumi.get(self, "override")
 
     @override.setter
-    def override(self, value: Optional[pulumi.Input['DeploymentScalingSpecHibernationSpecOverrideArgs']]):
+    def override(self, value: pulumi.Input[Optional['DeploymentScalingSpecHibernationSpecOverrideArgs']]):
         pulumi.set(self, "override", value)
 
     @_builtins.property
     @pulumi.getter
-    def schedules(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentScalingSpecHibernationSpecScheduleArgs']]]]:
+    def schedules(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentScalingSpecHibernationSpecScheduleArgs']]]]:
         """
         List of hibernation schedules. Set to null to remove all schedules.
         """
         return pulumi.get(self, "schedules")
 
     @schedules.setter
-    def schedules(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentScalingSpecHibernationSpecScheduleArgs']]]]):
+    def schedules(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentScalingSpecHibernationSpecScheduleArgs']]]]):
         pulumi.set(self, "schedules", value)
 
 
 class DeploymentScalingSpecHibernationSpecOverrideArgsDict(TypedDict):
     is_hibernating: pulumi.Input[_builtins.bool]
-    is_active: NotRequired[pulumi.Input[_builtins.bool]]
-    override_until: NotRequired[pulumi.Input[_builtins.str]]
+    is_active: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    override_until: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class DeploymentScalingSpecHibernationSpecOverrideArgs:
     def __init__(__self__, *,
                  is_hibernating: pulumi.Input[_builtins.bool],
-                 is_active: Optional[pulumi.Input[_builtins.bool]] = None,
-                 override_until: Optional[pulumi.Input[_builtins.str]] = None):
+                 is_active: pulumi.Input[Optional[_builtins.bool]] = None,
+                 override_until: pulumi.Input[Optional[_builtins.str]] = None):
         pulumi.set(__self__, "is_hibernating", is_hibernating)
         if is_active is not None:
             pulumi.set(__self__, "is_active", is_active)
@@ -2403,20 +2403,20 @@ class DeploymentScalingSpecHibernationSpecOverrideArgs:
 
     @_builtins.property
     @pulumi.getter(name="isActive")
-    def is_active(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_active(self) -> pulumi.Input[Optional[_builtins.bool]]:
         return pulumi.get(self, "is_active")
 
     @is_active.setter
-    def is_active(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_active(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_active", value)
 
     @_builtins.property
     @pulumi.getter(name="overrideUntil")
-    def override_until(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def override_until(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "override_until")
 
     @override_until.setter
-    def override_until(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def override_until(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "override_until", value)
 
 
@@ -2424,7 +2424,7 @@ class DeploymentScalingSpecHibernationSpecScheduleArgsDict(TypedDict):
     hibernate_at_cron: pulumi.Input[_builtins.str]
     is_enabled: pulumi.Input[_builtins.bool]
     wake_at_cron: pulumi.Input[_builtins.str]
-    description: NotRequired[pulumi.Input[_builtins.str]]
+    description: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class DeploymentScalingSpecHibernationSpecScheduleArgs:
@@ -2432,7 +2432,7 @@ class DeploymentScalingSpecHibernationSpecScheduleArgs:
                  hibernate_at_cron: pulumi.Input[_builtins.str],
                  is_enabled: pulumi.Input[_builtins.bool],
                  wake_at_cron: pulumi.Input[_builtins.str],
-                 description: Optional[pulumi.Input[_builtins.str]] = None):
+                 description: pulumi.Input[Optional[_builtins.str]] = None):
         pulumi.set(__self__, "hibernate_at_cron", hibernate_at_cron)
         pulumi.set(__self__, "is_enabled", is_enabled)
         pulumi.set(__self__, "wake_at_cron", wake_at_cron)
@@ -2468,47 +2468,47 @@ class DeploymentScalingSpecHibernationSpecScheduleArgs:
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
 
 class DeploymentScalingStatusArgsDict(TypedDict):
-    hibernation_status: NotRequired[pulumi.Input['DeploymentScalingStatusHibernationStatusArgsDict']]
+    hibernation_status: NotRequired[pulumi.Input[Optional['DeploymentScalingStatusHibernationStatusArgs']]]
 
 @pulumi.input_type
 class DeploymentScalingStatusArgs:
     def __init__(__self__, *,
-                 hibernation_status: Optional[pulumi.Input['DeploymentScalingStatusHibernationStatusArgs']] = None):
+                 hibernation_status: pulumi.Input[Optional['DeploymentScalingStatusHibernationStatusArgs']] = None):
         if hibernation_status is not None:
             pulumi.set(__self__, "hibernation_status", hibernation_status)
 
     @_builtins.property
     @pulumi.getter(name="hibernationStatus")
-    def hibernation_status(self) -> Optional[pulumi.Input['DeploymentScalingStatusHibernationStatusArgs']]:
+    def hibernation_status(self) -> pulumi.Input[Optional['DeploymentScalingStatusHibernationStatusArgs']]:
         return pulumi.get(self, "hibernation_status")
 
     @hibernation_status.setter
-    def hibernation_status(self, value: Optional[pulumi.Input['DeploymentScalingStatusHibernationStatusArgs']]):
+    def hibernation_status(self, value: pulumi.Input[Optional['DeploymentScalingStatusHibernationStatusArgs']]):
         pulumi.set(self, "hibernation_status", value)
 
 
 class DeploymentScalingStatusHibernationStatusArgsDict(TypedDict):
-    is_hibernating: NotRequired[pulumi.Input[_builtins.bool]]
-    next_event_at: NotRequired[pulumi.Input[_builtins.str]]
-    next_event_type: NotRequired[pulumi.Input[_builtins.str]]
-    reason: NotRequired[pulumi.Input[_builtins.str]]
+    is_hibernating: NotRequired[pulumi.Input[Optional[_builtins.bool]]]
+    next_event_at: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    next_event_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    reason: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class DeploymentScalingStatusHibernationStatusArgs:
     def __init__(__self__, *,
-                 is_hibernating: Optional[pulumi.Input[_builtins.bool]] = None,
-                 next_event_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 next_event_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 reason: Optional[pulumi.Input[_builtins.str]] = None):
+                 is_hibernating: pulumi.Input[Optional[_builtins.bool]] = None,
+                 next_event_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 next_event_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 reason: pulumi.Input[Optional[_builtins.str]] = None):
         if is_hibernating is not None:
             pulumi.set(__self__, "is_hibernating", is_hibernating)
         if next_event_at is not None:
@@ -2520,58 +2520,58 @@ class DeploymentScalingStatusHibernationStatusArgs:
 
     @_builtins.property
     @pulumi.getter(name="isHibernating")
-    def is_hibernating(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_hibernating(self) -> pulumi.Input[Optional[_builtins.bool]]:
         return pulumi.get(self, "is_hibernating")
 
     @is_hibernating.setter
-    def is_hibernating(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_hibernating(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_hibernating", value)
 
     @_builtins.property
     @pulumi.getter(name="nextEventAt")
-    def next_event_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def next_event_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "next_event_at")
 
     @next_event_at.setter
-    def next_event_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def next_event_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "next_event_at", value)
 
     @_builtins.property
     @pulumi.getter(name="nextEventType")
-    def next_event_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def next_event_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "next_event_type")
 
     @next_event_type.setter
-    def next_event_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def next_event_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "next_event_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def reason(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def reason(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "reason")
 
     @reason.setter
-    def reason(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def reason(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "reason", value)
 
 
 class DeploymentUpdatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class DeploymentUpdatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -2587,56 +2587,56 @@ class DeploymentUpdatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
@@ -2661,19 +2661,19 @@ class DeploymentWorkerQueueArgsDict(TypedDict):
     """
     Worker queue worker concurrency
     """
-    astro_machine: NotRequired[pulumi.Input[_builtins.str]]
+    astro_machine: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Worker queue Astro machine value - required for 'STANDARD' and 'DEDICATED' deployments. Allowed values: `A5`, `A10`, `A20`, `A40`, `A60`, `A120`, `A160`.
     """
-    node_pool_id: NotRequired[pulumi.Input[_builtins.str]]
+    node_pool_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Worker queue Node pool identifier - required for 'HYBRID' deployments
     """
-    pod_cpu: NotRequired[pulumi.Input[_builtins.str]]
+    pod_cpu: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Worker queue pod CPU
     """
-    pod_memory: NotRequired[pulumi.Input[_builtins.str]]
+    pod_memory: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     Worker queue pod memory
     """
@@ -2686,10 +2686,10 @@ class DeploymentWorkerQueueArgs:
                  min_worker_count: pulumi.Input[_builtins.int],
                  name: pulumi.Input[_builtins.str],
                  worker_concurrency: pulumi.Input[_builtins.int],
-                 astro_machine: Optional[pulumi.Input[_builtins.str]] = None,
-                 node_pool_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 pod_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 pod_memory: Optional[pulumi.Input[_builtins.str]] = None):
+                 astro_machine: pulumi.Input[Optional[_builtins.str]] = None,
+                 node_pool_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 pod_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 pod_memory: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.bool] is_default: Worker queue default
         :param pulumi.Input[_builtins.int] max_worker_count: Worker queue max worker count
@@ -2777,70 +2777,70 @@ class DeploymentWorkerQueueArgs:
 
     @_builtins.property
     @pulumi.getter(name="astroMachine")
-    def astro_machine(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def astro_machine(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Worker queue Astro machine value - required for 'STANDARD' and 'DEDICATED' deployments. Allowed values: `A5`, `A10`, `A20`, `A40`, `A60`, `A120`, `A160`.
         """
         return pulumi.get(self, "astro_machine")
 
     @astro_machine.setter
-    def astro_machine(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def astro_machine(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "astro_machine", value)
 
     @_builtins.property
     @pulumi.getter(name="nodePoolId")
-    def node_pool_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def node_pool_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Worker queue Node pool identifier - required for 'HYBRID' deployments
         """
         return pulumi.get(self, "node_pool_id")
 
     @node_pool_id.setter
-    def node_pool_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def node_pool_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "node_pool_id", value)
 
     @_builtins.property
     @pulumi.getter(name="podCpu")
-    def pod_cpu(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def pod_cpu(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Worker queue pod CPU
         """
         return pulumi.get(self, "pod_cpu")
 
     @pod_cpu.setter
-    def pod_cpu(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def pod_cpu(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "pod_cpu", value)
 
     @_builtins.property
     @pulumi.getter(name="podMemory")
-    def pod_memory(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def pod_memory(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Worker queue pod memory
         """
         return pulumi.get(self, "pod_memory")
 
     @pod_memory.setter
-    def pod_memory(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def pod_memory(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "pod_memory", value)
 
 
 class NotificationChannelCreatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class NotificationChannelCreatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -2856,85 +2856,85 @@ class NotificationChannelCreatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
 class NotificationChannelDefinitionArgsDict(TypedDict):
-    api_key: NotRequired[pulumi.Input[_builtins.str]]
+    api_key: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The API key for the notification channel
     """
-    dag_id: NotRequired[pulumi.Input[_builtins.str]]
+    dag_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The DAG ID for the notification channel
     """
-    deployment_api_token: NotRequired[pulumi.Input[_builtins.str]]
+    deployment_api_token: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The deployment API token for the notification channel
     """
-    deployment_id: NotRequired[pulumi.Input[_builtins.str]]
+    deployment_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The deployment ID for the notification channel
     """
-    integration_key: NotRequired[pulumi.Input[_builtins.str]]
+    integration_key: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The integration key for the notification channel
     """
-    recipients: NotRequired[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]
+    recipients: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]]
     """
     The recipients for the notification channel
     """
-    webhook_url: NotRequired[pulumi.Input[_builtins.str]]
+    webhook_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The webhook URL for the notification channel
     """
@@ -2942,13 +2942,13 @@ class NotificationChannelDefinitionArgsDict(TypedDict):
 @pulumi.input_type
 class NotificationChannelDefinitionArgs:
     def __init__(__self__, *,
-                 api_key: Optional[pulumi.Input[_builtins.str]] = None,
-                 dag_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 deployment_api_token: Optional[pulumi.Input[_builtins.str]] = None,
-                 deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 integration_key: Optional[pulumi.Input[_builtins.str]] = None,
-                 recipients: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 webhook_url: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_key: pulumi.Input[Optional[_builtins.str]] = None,
+                 dag_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 deployment_api_token: pulumi.Input[Optional[_builtins.str]] = None,
+                 deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 integration_key: pulumi.Input[Optional[_builtins.str]] = None,
+                 recipients: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 webhook_url: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] api_key: The API key for the notification channel
         :param pulumi.Input[_builtins.str] dag_id: The DAG ID for the notification channel
@@ -2975,106 +2975,106 @@ class NotificationChannelDefinitionArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiKey")
-    def api_key(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_key(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The API key for the notification channel
         """
         return pulumi.get(self, "api_key")
 
     @api_key.setter
-    def api_key(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_key(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_key", value)
 
     @_builtins.property
     @pulumi.getter(name="dagId")
-    def dag_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dag_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The DAG ID for the notification channel
         """
         return pulumi.get(self, "dag_id")
 
     @dag_id.setter
-    def dag_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dag_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dag_id", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentApiToken")
-    def deployment_api_token(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def deployment_api_token(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The deployment API token for the notification channel
         """
         return pulumi.get(self, "deployment_api_token")
 
     @deployment_api_token.setter
-    def deployment_api_token(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def deployment_api_token(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "deployment_api_token", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentId")
-    def deployment_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def deployment_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The deployment ID for the notification channel
         """
         return pulumi.get(self, "deployment_id")
 
     @deployment_id.setter
-    def deployment_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def deployment_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "deployment_id", value)
 
     @_builtins.property
     @pulumi.getter(name="integrationKey")
-    def integration_key(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def integration_key(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The integration key for the notification channel
         """
         return pulumi.get(self, "integration_key")
 
     @integration_key.setter
-    def integration_key(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def integration_key(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "integration_key", value)
 
     @_builtins.property
     @pulumi.getter
-    def recipients(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def recipients(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The recipients for the notification channel
         """
         return pulumi.get(self, "recipients")
 
     @recipients.setter
-    def recipients(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def recipients(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "recipients", value)
 
     @_builtins.property
     @pulumi.getter(name="webhookUrl")
-    def webhook_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def webhook_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The webhook URL for the notification channel
         """
         return pulumi.get(self, "webhook_url")
 
     @webhook_url.setter
-    def webhook_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def webhook_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "webhook_url", value)
 
 
 class NotificationChannelUpdatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class NotificationChannelUpdatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -3090,76 +3090,76 @@ class NotificationChannelUpdatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
 class TeamCreatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class TeamCreatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -3175,56 +3175,56 @@ class TeamCreatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
@@ -3237,11 +3237,11 @@ class TeamDagRoleArgsDict(TypedDict):
     """
     The DAG role (DAG*VIEWER, DAG*AUTHOR, or custom DAG role).
     """
-    dag_id: NotRequired[pulumi.Input[_builtins.str]]
+    dag_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The DAG ID. Required if tag is not specified.
     """
-    tag: NotRequired[pulumi.Input[_builtins.str]]
+    tag: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The DAG tag. Required if dag_id is not specified.
     """
@@ -3251,8 +3251,8 @@ class TeamDagRoleArgs:
     def __init__(__self__, *,
                  deployment_id: pulumi.Input[_builtins.str],
                  role: pulumi.Input[_builtins.str],
-                 dag_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 tag: Optional[pulumi.Input[_builtins.str]] = None):
+                 dag_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 tag: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] deployment_id: The Deployment ID containing the DAG.
         :param pulumi.Input[_builtins.str] role: The DAG role (DAG*VIEWER, DAG*AUTHOR, or custom DAG role).
@@ -3292,26 +3292,26 @@ class TeamDagRoleArgs:
 
     @_builtins.property
     @pulumi.getter(name="dagId")
-    def dag_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dag_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The DAG ID. Required if tag is not specified.
         """
         return pulumi.get(self, "dag_id")
 
     @dag_id.setter
-    def dag_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dag_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dag_id", value)
 
     @_builtins.property
     @pulumi.getter
-    def tag(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def tag(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The DAG tag. Required if dag_id is not specified.
         """
         return pulumi.get(self, "tag")
 
     @tag.setter
-    def tag(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def tag(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "tag", value)
 
 
@@ -3371,11 +3371,11 @@ class TeamRolesDagRoleArgsDict(TypedDict):
     """
     The DAG role (DAG*VIEWER, DAG*AUTHOR, or custom DAG role).
     """
-    dag_id: NotRequired[pulumi.Input[_builtins.str]]
+    dag_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The DAG ID. Required if tag is not specified.
     """
-    tag: NotRequired[pulumi.Input[_builtins.str]]
+    tag: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The DAG tag. Required if dag_id is not specified.
     """
@@ -3385,8 +3385,8 @@ class TeamRolesDagRoleArgs:
     def __init__(__self__, *,
                  deployment_id: pulumi.Input[_builtins.str],
                  role: pulumi.Input[_builtins.str],
-                 dag_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 tag: Optional[pulumi.Input[_builtins.str]] = None):
+                 dag_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 tag: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] deployment_id: The Deployment ID containing the DAG.
         :param pulumi.Input[_builtins.str] role: The DAG role (DAG*VIEWER, DAG*AUTHOR, or custom DAG role).
@@ -3426,26 +3426,26 @@ class TeamRolesDagRoleArgs:
 
     @_builtins.property
     @pulumi.getter(name="dagId")
-    def dag_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dag_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The DAG ID. Required if tag is not specified.
         """
         return pulumi.get(self, "dag_id")
 
     @dag_id.setter
-    def dag_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dag_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dag_id", value)
 
     @_builtins.property
     @pulumi.getter
-    def tag(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def tag(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The DAG tag. Required if dag_id is not specified.
         """
         return pulumi.get(self, "tag")
 
     @tag.setter
-    def tag(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def tag(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "tag", value)
 
 
@@ -3544,22 +3544,22 @@ class TeamRolesWorkspaceRoleArgs:
 
 
 class TeamUpdatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class TeamUpdatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -3575,56 +3575,56 @@ class TeamUpdatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
@@ -3676,22 +3676,22 @@ class TeamWorkspaceRoleArgs:
 
 
 class UserInviteInviteeArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class UserInviteInviteeArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -3707,76 +3707,76 @@ class UserInviteInviteeArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
 class UserInviteInviterArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class UserInviteInviterArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -3792,56 +3792,56 @@ class UserInviteInviterArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
@@ -3854,11 +3854,11 @@ class UserRolesDagRoleArgsDict(TypedDict):
     """
     The DAG role (DAG*VIEWER, DAG*AUTHOR, or custom DAG role).
     """
-    dag_id: NotRequired[pulumi.Input[_builtins.str]]
+    dag_id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The DAG ID. Required if tag is not specified.
     """
-    tag: NotRequired[pulumi.Input[_builtins.str]]
+    tag: NotRequired[pulumi.Input[Optional[_builtins.str]]]
     """
     The DAG tag. Required if dag_id is not specified.
     """
@@ -3868,8 +3868,8 @@ class UserRolesDagRoleArgs:
     def __init__(__self__, *,
                  deployment_id: pulumi.Input[_builtins.str],
                  role: pulumi.Input[_builtins.str],
-                 dag_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 tag: Optional[pulumi.Input[_builtins.str]] = None):
+                 dag_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 tag: pulumi.Input[Optional[_builtins.str]] = None):
         """
         :param pulumi.Input[_builtins.str] deployment_id: The Deployment ID containing the DAG.
         :param pulumi.Input[_builtins.str] role: The DAG role (DAG*VIEWER, DAG*AUTHOR, or custom DAG role).
@@ -3909,26 +3909,26 @@ class UserRolesDagRoleArgs:
 
     @_builtins.property
     @pulumi.getter(name="dagId")
-    def dag_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dag_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The DAG ID. Required if tag is not specified.
         """
         return pulumi.get(self, "dag_id")
 
     @dag_id.setter
-    def dag_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dag_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dag_id", value)
 
     @_builtins.property
     @pulumi.getter
-    def tag(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def tag(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The DAG tag. Required if dag_id is not specified.
         """
         return pulumi.get(self, "tag")
 
     @tag.setter
-    def tag(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def tag(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "tag", value)
 
 
@@ -4027,22 +4027,22 @@ class UserRolesWorkspaceRoleArgs:
 
 
 class WorkspaceCreatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class WorkspaceCreatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -4058,76 +4058,76 @@ class WorkspaceCreatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 
 class WorkspaceUpdatedByArgsDict(TypedDict):
-    api_token_name: NotRequired[pulumi.Input[_builtins.str]]
-    avatar_url: NotRequired[pulumi.Input[_builtins.str]]
-    full_name: NotRequired[pulumi.Input[_builtins.str]]
-    id: NotRequired[pulumi.Input[_builtins.str]]
-    subject_type: NotRequired[pulumi.Input[_builtins.str]]
-    username: NotRequired[pulumi.Input[_builtins.str]]
+    api_token_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    avatar_url: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    full_name: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    id: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    subject_type: NotRequired[pulumi.Input[Optional[_builtins.str]]]
+    username: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type
 class WorkspaceUpdatedByArgs:
     def __init__(__self__, *,
-                 api_token_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 avatar_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 full_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 id: Optional[pulumi.Input[_builtins.str]] = None,
-                 subject_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 username: Optional[pulumi.Input[_builtins.str]] = None):
+                 api_token_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 avatar_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 full_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 id: pulumi.Input[Optional[_builtins.str]] = None,
+                 subject_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 username: pulumi.Input[Optional[_builtins.str]] = None):
         if api_token_name is not None:
             pulumi.set(__self__, "api_token_name", api_token_name)
         if avatar_url is not None:
@@ -4143,56 +4143,56 @@ class WorkspaceUpdatedByArgs:
 
     @_builtins.property
     @pulumi.getter(name="apiTokenName")
-    def api_token_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def api_token_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "api_token_name")
 
     @api_token_name.setter
-    def api_token_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def api_token_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "api_token_name", value)
 
     @_builtins.property
     @pulumi.getter(name="avatarUrl")
-    def avatar_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def avatar_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "avatar_url")
 
     @avatar_url.setter
-    def avatar_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def avatar_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "avatar_url", value)
 
     @_builtins.property
     @pulumi.getter(name="fullName")
-    def full_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def full_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "full_name")
 
     @full_name.setter
-    def full_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def full_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "full_name", value)
 
     @_builtins.property
     @pulumi.getter
-    def id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def id(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "id")
 
     @id.setter
-    def id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "id", value)
 
     @_builtins.property
     @pulumi.getter(name="subjectType")
-    def subject_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def subject_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "subject_type")
 
     @subject_type.setter
-    def subject_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def subject_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "subject_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def username(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def username(self) -> pulumi.Input[Optional[_builtins.str]]:
         return pulumi.get(self, "username")
 
     @username.setter
-    def username(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def username(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "username", value)
 
 

--- a/sdk/python/pulumi_astronomer/agent_token.py
+++ b/sdk/python/pulumi_astronomer/agent_token.py
@@ -20,9 +20,9 @@ __all__ = ['AgentTokenArgs', 'AgentToken']
 class AgentTokenArgs:
     def __init__(__self__, *,
                  deployment_id: pulumi.Input[_builtins.str],
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None):
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None):
         """
         The set of arguments for constructing a AgentToken resource.
 
@@ -53,49 +53,49 @@ class AgentTokenArgs:
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Agent Token description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter(name="expiryPeriodInDays")
-    def expiry_period_in_days(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def expiry_period_in_days(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         Agent Token expiry period in days. If not set, the token will not expire.
         """
         return pulumi.get(self, "expiry_period_in_days")
 
     @expiry_period_in_days.setter
-    def expiry_period_in_days(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def expiry_period_in_days(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "expiry_period_in_days", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Agent Token name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
 class _AgentTokenState:
     def __init__(__self__, *,
-                 deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 token: Optional[pulumi.Input[_builtins.str]] = None):
+                 deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 token: pulumi.Input[Optional[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering AgentToken resources.
 
@@ -118,62 +118,62 @@ class _AgentTokenState:
 
     @_builtins.property
     @pulumi.getter(name="deploymentId")
-    def deployment_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def deployment_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         ID of the deployment this agent token belongs to
         """
         return pulumi.get(self, "deployment_id")
 
     @deployment_id.setter
-    def deployment_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def deployment_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "deployment_id", value)
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Agent Token description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter(name="expiryPeriodInDays")
-    def expiry_period_in_days(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def expiry_period_in_days(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         Agent Token expiry period in days. If not set, the token will not expire.
         """
         return pulumi.get(self, "expiry_period_in_days")
 
     @expiry_period_in_days.setter
-    def expiry_period_in_days(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def expiry_period_in_days(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "expiry_period_in_days", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Agent Token name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter
-    def token(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def token(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Agent Token value. Warning: This value will be saved in plaintext in the terraform state file.
         """
         return pulumi.get(self, "token")
 
     @token.setter
-    def token(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def token(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "token", value)
 
 
@@ -183,10 +183,10 @@ class AgentToken(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
+                 deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         Agent Token resource
@@ -224,10 +224,10 @@ class AgentToken(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
+                 deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -256,11 +256,11 @@ class AgentToken(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-            description: Optional[pulumi.Input[_builtins.str]] = None,
-            expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-            name: Optional[pulumi.Input[_builtins.str]] = None,
-            token: Optional[pulumi.Input[_builtins.str]] = None) -> 'AgentToken':
+            deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+            description: pulumi.Input[Optional[_builtins.str]] = None,
+            expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+            name: pulumi.Input[Optional[_builtins.str]] = None,
+            token: pulumi.Input[Optional[_builtins.str]] = None) -> 'AgentToken':
         """
         Get an existing AgentToken resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/alert.py
+++ b/sdk/python/pulumi_astronomer/alert.py
@@ -27,7 +27,7 @@ class AlertArgs:
                  rules: pulumi.Input['AlertRulesArgs'],
                  severity: pulumi.Input[_builtins.str],
                  type: pulumi.Input[_builtins.str],
-                 name: Optional[pulumi.Input[_builtins.str]] = None):
+                 name: pulumi.Input[Optional[_builtins.str]] = None):
         """
         The set of arguments for constructing a Alert resource.
 
@@ -122,35 +122,35 @@ class AlertArgs:
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Alert name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
 class _AlertState:
     def __init__(__self__, *,
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_by: Optional[pulumi.Input['AlertCreatedByArgs']] = None,
-                 deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 notification_channel_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 notification_channels: Optional[pulumi.Input[Sequence[pulumi.Input['AlertNotificationChannelArgs']]]] = None,
-                 rules: Optional[pulumi.Input['AlertRulesArgs']] = None,
-                 severity: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_by: Optional[pulumi.Input['AlertUpdatedByArgs']] = None,
-                 workspace_id: Optional[pulumi.Input[_builtins.str]] = None):
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_by: pulumi.Input[Optional['AlertCreatedByArgs']] = None,
+                 deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 notification_channel_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 notification_channels: pulumi.Input[Optional[Sequence[pulumi.Input['AlertNotificationChannelArgs']]]] = None,
+                 rules: pulumi.Input[Optional['AlertRulesArgs']] = None,
+                 severity: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_by: pulumi.Input[Optional['AlertUpdatedByArgs']] = None,
+                 workspace_id: pulumi.Input[Optional[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering Alert resources.
 
@@ -203,182 +203,182 @@ class _AlertState:
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Alert creation timestamp
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter(name="createdBy")
-    def created_by(self) -> Optional[pulumi.Input['AlertCreatedByArgs']]:
+    def created_by(self) -> pulumi.Input[Optional['AlertCreatedByArgs']]:
         """
         Alert creator
         """
         return pulumi.get(self, "created_by")
 
     @created_by.setter
-    def created_by(self, value: Optional[pulumi.Input['AlertCreatedByArgs']]):
+    def created_by(self, value: pulumi.Input[Optional['AlertCreatedByArgs']]):
         pulumi.set(self, "created_by", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentId")
-    def deployment_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def deployment_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the Deployment to which the alert is scoped
         """
         return pulumi.get(self, "deployment_id")
 
     @deployment_id.setter
-    def deployment_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def deployment_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "deployment_id", value)
 
     @_builtins.property
     @pulumi.getter(name="entityId")
-    def entity_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def entity_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The entity ID the alert is associated with
         """
         return pulumi.get(self, "entity_id")
 
     @entity_id.setter
-    def entity_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def entity_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "entity_id", value)
 
     @_builtins.property
     @pulumi.getter(name="entityName")
-    def entity_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def entity_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The name of the entity the alert is associated with
         """
         return pulumi.get(self, "entity_name")
 
     @entity_name.setter
-    def entity_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def entity_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "entity_name", value)
 
     @_builtins.property
     @pulumi.getter(name="entityType")
-    def entity_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def entity_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the Deployment to which the alert is scoped
         """
         return pulumi.get(self, "entity_type")
 
     @entity_type.setter
-    def entity_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def entity_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "entity_type", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Alert name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter(name="notificationChannelIds")
-    def notification_channel_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def notification_channel_ids(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         Set of notification channel identifiers to notify when the alert is triggered
         """
         return pulumi.get(self, "notification_channel_ids")
 
     @notification_channel_ids.setter
-    def notification_channel_ids(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def notification_channel_ids(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "notification_channel_ids", value)
 
     @_builtins.property
     @pulumi.getter(name="notificationChannels")
-    def notification_channels(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['AlertNotificationChannelArgs']]]]:
+    def notification_channels(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['AlertNotificationChannelArgs']]]]:
         """
         The notification channels to send alerts to
         """
         return pulumi.get(self, "notification_channels")
 
     @notification_channels.setter
-    def notification_channels(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['AlertNotificationChannelArgs']]]]):
+    def notification_channels(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['AlertNotificationChannelArgs']]]]):
         pulumi.set(self, "notification_channels", value)
 
     @_builtins.property
     @pulumi.getter
-    def rules(self) -> Optional[pulumi.Input['AlertRulesArgs']]:
+    def rules(self) -> pulumi.Input[Optional['AlertRulesArgs']]:
         """
         Alert rules defining the conditions for triggering the alert
         """
         return pulumi.get(self, "rules")
 
     @rules.setter
-    def rules(self, value: Optional[pulumi.Input['AlertRulesArgs']]):
+    def rules(self, value: pulumi.Input[Optional['AlertRulesArgs']]):
         pulumi.set(self, "rules", value)
 
     @_builtins.property
     @pulumi.getter
-    def severity(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def severity(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The alert's severity
         """
         return pulumi.get(self, "severity")
 
     @severity.setter
-    def severity(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def severity(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "severity", value)
 
     @_builtins.property
     @pulumi.getter
-    def type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The alert's type
         """
         return pulumi.get(self, "type")
 
     @type.setter
-    def type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "type", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Alert last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedBy")
-    def updated_by(self) -> Optional[pulumi.Input['AlertUpdatedByArgs']]:
+    def updated_by(self) -> pulumi.Input[Optional['AlertUpdatedByArgs']]:
         """
         Alert updater
         """
         return pulumi.get(self, "updated_by")
 
     @updated_by.setter
-    def updated_by(self, value: Optional[pulumi.Input['AlertUpdatedByArgs']]):
+    def updated_by(self, value: pulumi.Input[Optional['AlertUpdatedByArgs']]):
         pulumi.set(self, "updated_by", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def workspace_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the Workspace to which the alert is scoped
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def workspace_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -388,13 +388,13 @@ class Alert(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 entity_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 notification_channel_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 rules: Optional[pulumi.Input[Union['AlertRulesArgs', 'AlertRulesArgsDict']]] = None,
-                 severity: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
+                 entity_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 notification_channel_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 rules: pulumi.Input[Optional[Union['AlertRulesArgs', 'AlertRulesArgsDict']]] = None,
+                 severity: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         Alert resource
@@ -435,13 +435,13 @@ class Alert(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 entity_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 notification_channel_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 rules: Optional[pulumi.Input[Union['AlertRulesArgs', 'AlertRulesArgsDict']]] = None,
-                 severity: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
+                 entity_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 notification_channel_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 rules: pulumi.Input[Optional[Union['AlertRulesArgs', 'AlertRulesArgsDict']]] = None,
+                 severity: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -488,21 +488,21 @@ class Alert(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            created_at: Optional[pulumi.Input[_builtins.str]] = None,
-            created_by: Optional[pulumi.Input[Union['AlertCreatedByArgs', 'AlertCreatedByArgsDict']]] = None,
-            deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-            entity_id: Optional[pulumi.Input[_builtins.str]] = None,
-            entity_name: Optional[pulumi.Input[_builtins.str]] = None,
-            entity_type: Optional[pulumi.Input[_builtins.str]] = None,
-            name: Optional[pulumi.Input[_builtins.str]] = None,
-            notification_channel_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-            notification_channels: Optional[pulumi.Input[Sequence[pulumi.Input[Union['AlertNotificationChannelArgs', 'AlertNotificationChannelArgsDict']]]]] = None,
-            rules: Optional[pulumi.Input[Union['AlertRulesArgs', 'AlertRulesArgsDict']]] = None,
-            severity: Optional[pulumi.Input[_builtins.str]] = None,
-            type: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_by: Optional[pulumi.Input[Union['AlertUpdatedByArgs', 'AlertUpdatedByArgsDict']]] = None,
-            workspace_id: Optional[pulumi.Input[_builtins.str]] = None) -> 'Alert':
+            created_at: pulumi.Input[Optional[_builtins.str]] = None,
+            created_by: pulumi.Input[Optional[Union['AlertCreatedByArgs', 'AlertCreatedByArgsDict']]] = None,
+            deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+            entity_id: pulumi.Input[Optional[_builtins.str]] = None,
+            entity_name: pulumi.Input[Optional[_builtins.str]] = None,
+            entity_type: pulumi.Input[Optional[_builtins.str]] = None,
+            name: pulumi.Input[Optional[_builtins.str]] = None,
+            notification_channel_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+            notification_channels: pulumi.Input[Optional[Sequence[pulumi.Input[Union['AlertNotificationChannelArgs', 'AlertNotificationChannelArgsDict']]]]] = None,
+            rules: pulumi.Input[Optional[Union['AlertRulesArgs', 'AlertRulesArgsDict']]] = None,
+            severity: pulumi.Input[Optional[_builtins.str]] = None,
+            type: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_by: pulumi.Input[Optional[Union['AlertUpdatedByArgs', 'AlertUpdatedByArgsDict']]] = None,
+            workspace_id: pulumi.Input[Optional[_builtins.str]] = None) -> 'Alert':
         """
         Get an existing Alert resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/api_token.py
+++ b/sdk/python/pulumi_astronomer/api_token.py
@@ -23,9 +23,9 @@ class ApiTokenArgs:
     def __init__(__self__, *,
                  roles: pulumi.Input[Sequence[pulumi.Input['ApiTokenRoleArgs']]],
                  type: pulumi.Input[_builtins.str],
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None):
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None):
         """
         The set of arguments for constructing a ApiToken resource.
 
@@ -70,58 +70,58 @@ class ApiTokenArgs:
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter(name="expiryPeriodInDays")
-    def expiry_period_in_days(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def expiry_period_in_days(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         API Token expiry period in days
         """
         return pulumi.get(self, "expiry_period_in_days")
 
     @expiry_period_in_days.setter
-    def expiry_period_in_days(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def expiry_period_in_days(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "expiry_period_in_days", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
 class _ApiTokenState:
     def __init__(__self__, *,
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_by: Optional[pulumi.Input['ApiTokenCreatedByArgs']] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 end_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-                 last_used_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 roles: Optional[pulumi.Input[Sequence[pulumi.Input['ApiTokenRoleArgs']]]] = None,
-                 short_token: Optional[pulumi.Input[_builtins.str]] = None,
-                 start_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 token: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_by: Optional[pulumi.Input['ApiTokenUpdatedByArgs']] = None):
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_by: pulumi.Input[Optional['ApiTokenCreatedByArgs']] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 end_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+                 last_used_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 roles: pulumi.Input[Optional[Sequence[pulumi.Input['ApiTokenRoleArgs']]]] = None,
+                 short_token: pulumi.Input[Optional[_builtins.str]] = None,
+                 start_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 token: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_by: pulumi.Input[Optional['ApiTokenUpdatedByArgs']] = None):
         """
         Input properties used for looking up and filtering ApiToken resources.
 
@@ -171,170 +171,170 @@ class _ApiTokenState:
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token creation timestamp
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter(name="createdBy")
-    def created_by(self) -> Optional[pulumi.Input['ApiTokenCreatedByArgs']]:
+    def created_by(self) -> pulumi.Input[Optional['ApiTokenCreatedByArgs']]:
         """
         API Token creator
         """
         return pulumi.get(self, "created_by")
 
     @created_by.setter
-    def created_by(self, value: Optional[pulumi.Input['ApiTokenCreatedByArgs']]):
+    def created_by(self, value: pulumi.Input[Optional['ApiTokenCreatedByArgs']]):
         pulumi.set(self, "created_by", value)
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter(name="endAt")
-    def end_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def end_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         time when the API token will expire in UTC
         """
         return pulumi.get(self, "end_at")
 
     @end_at.setter
-    def end_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def end_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "end_at", value)
 
     @_builtins.property
     @pulumi.getter(name="expiryPeriodInDays")
-    def expiry_period_in_days(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def expiry_period_in_days(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         API Token expiry period in days
         """
         return pulumi.get(self, "expiry_period_in_days")
 
     @expiry_period_in_days.setter
-    def expiry_period_in_days(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def expiry_period_in_days(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "expiry_period_in_days", value)
 
     @_builtins.property
     @pulumi.getter(name="lastUsedAt")
-    def last_used_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def last_used_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token last used timestamp
         """
         return pulumi.get(self, "last_used_at")
 
     @last_used_at.setter
-    def last_used_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def last_used_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "last_used_at", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter
-    def roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['ApiTokenRoleArgs']]]]:
+    def roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['ApiTokenRoleArgs']]]]:
         """
         The roles assigned to the API Token
         """
         return pulumi.get(self, "roles")
 
     @roles.setter
-    def roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ApiTokenRoleArgs']]]]):
+    def roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['ApiTokenRoleArgs']]]]):
         pulumi.set(self, "roles", value)
 
     @_builtins.property
     @pulumi.getter(name="shortToken")
-    def short_token(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def short_token(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token short token
         """
         return pulumi.get(self, "short_token")
 
     @short_token.setter
-    def short_token(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def short_token(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "short_token", value)
 
     @_builtins.property
     @pulumi.getter(name="startAt")
-    def start_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def start_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         time when the API token will become valid in UTC
         """
         return pulumi.get(self, "start_at")
 
     @start_at.setter
-    def start_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def start_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "start_at", value)
 
     @_builtins.property
     @pulumi.getter
-    def token(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def token(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token value. Warning: This value will be saved in plaintext in the terraform state file.
         """
         return pulumi.get(self, "token")
 
     @token.setter
-    def token(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def token(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "token", value)
 
     @_builtins.property
     @pulumi.getter
-    def type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token type - if changing this value, the API Token will be recreated with the new type
         """
         return pulumi.get(self, "type")
 
     @type.setter
-    def type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "type", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API Token last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedBy")
-    def updated_by(self) -> Optional[pulumi.Input['ApiTokenUpdatedByArgs']]:
+    def updated_by(self) -> pulumi.Input[Optional['ApiTokenUpdatedByArgs']]:
         """
         API Token updater
         """
         return pulumi.get(self, "updated_by")
 
     @updated_by.setter
-    def updated_by(self, value: Optional[pulumi.Input['ApiTokenUpdatedByArgs']]):
+    def updated_by(self, value: pulumi.Input[Optional['ApiTokenUpdatedByArgs']]):
         pulumi.set(self, "updated_by", value)
 
 
@@ -344,11 +344,11 @@ class ApiToken(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ApiTokenRoleArgs', 'ApiTokenRoleArgsDict']]]]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['ApiTokenRoleArgs', 'ApiTokenRoleArgsDict']]]]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         API Token resource
@@ -387,11 +387,11 @@ class ApiToken(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ApiTokenRoleArgs', 'ApiTokenRoleArgsDict']]]]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['ApiTokenRoleArgs', 'ApiTokenRoleArgsDict']]]]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -431,20 +431,20 @@ class ApiToken(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            created_at: Optional[pulumi.Input[_builtins.str]] = None,
-            created_by: Optional[pulumi.Input[Union['ApiTokenCreatedByArgs', 'ApiTokenCreatedByArgsDict']]] = None,
-            description: Optional[pulumi.Input[_builtins.str]] = None,
-            end_at: Optional[pulumi.Input[_builtins.str]] = None,
-            expiry_period_in_days: Optional[pulumi.Input[_builtins.int]] = None,
-            last_used_at: Optional[pulumi.Input[_builtins.str]] = None,
-            name: Optional[pulumi.Input[_builtins.str]] = None,
-            roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ApiTokenRoleArgs', 'ApiTokenRoleArgsDict']]]]] = None,
-            short_token: Optional[pulumi.Input[_builtins.str]] = None,
-            start_at: Optional[pulumi.Input[_builtins.str]] = None,
-            token: Optional[pulumi.Input[_builtins.str]] = None,
-            type: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_by: Optional[pulumi.Input[Union['ApiTokenUpdatedByArgs', 'ApiTokenUpdatedByArgsDict']]] = None) -> 'ApiToken':
+            created_at: pulumi.Input[Optional[_builtins.str]] = None,
+            created_by: pulumi.Input[Optional[Union['ApiTokenCreatedByArgs', 'ApiTokenCreatedByArgsDict']]] = None,
+            description: pulumi.Input[Optional[_builtins.str]] = None,
+            end_at: pulumi.Input[Optional[_builtins.str]] = None,
+            expiry_period_in_days: pulumi.Input[Optional[_builtins.int]] = None,
+            last_used_at: pulumi.Input[Optional[_builtins.str]] = None,
+            name: pulumi.Input[Optional[_builtins.str]] = None,
+            roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['ApiTokenRoleArgs', 'ApiTokenRoleArgsDict']]]]] = None,
+            short_token: pulumi.Input[Optional[_builtins.str]] = None,
+            start_at: pulumi.Input[Optional[_builtins.str]] = None,
+            token: pulumi.Input[Optional[_builtins.str]] = None,
+            type: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_by: pulumi.Input[Optional[Union['ApiTokenUpdatedByArgs', 'ApiTokenUpdatedByArgsDict']]] = None) -> 'ApiToken':
         """
         Get an existing ApiToken resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/cluster.py
+++ b/sdk/python/pulumi_astronomer/cluster.py
@@ -26,17 +26,17 @@ class ClusterArgs:
                  type: pulumi.Input[_builtins.str],
                  vpc_subnet_range: pulumi.Input[_builtins.str],
                  workspace_ids: pulumi.Input[Sequence[pulumi.Input[_builtins.str]]],
-                 dr_region: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_secondary_vpc_cidr: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_vpc_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 enable_replication_time_control: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_dr_enabled: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_failed_over: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 pod_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 service_peering_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 service_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 timeouts: Optional[pulumi.Input['ClusterTimeoutsArgs']] = None):
+                 dr_region: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_secondary_vpc_cidr: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_vpc_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 enable_replication_time_control: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_dr_enabled: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_failed_over: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 pod_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 service_peering_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 service_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 timeouts: pulumi.Input[Optional['ClusterTimeoutsArgs']] = None):
         """
         The set of arguments for constructing a Cluster resource.
 
@@ -146,163 +146,163 @@ class ClusterArgs:
 
     @_builtins.property
     @pulumi.getter(name="drRegion")
-    def dr_region(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dr_region(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The secondary region for Disaster Recovery. Required when `is_dr_enabled` is true. Cannot be changed once set.
         """
         return pulumi.get(self, "dr_region")
 
     @dr_region.setter
-    def dr_region(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dr_region(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dr_region", value)
 
     @_builtins.property
     @pulumi.getter(name="drSecondaryVpcCidr")
-    def dr_secondary_vpc_cidr(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dr_secondary_vpc_cidr(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Secondary CIDR for pod networking in the DR region (AWS only). Cannot be changed once set.
         """
         return pulumi.get(self, "dr_secondary_vpc_cidr")
 
     @dr_secondary_vpc_cidr.setter
-    def dr_secondary_vpc_cidr(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dr_secondary_vpc_cidr(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dr_secondary_vpc_cidr", value)
 
     @_builtins.property
     @pulumi.getter(name="drVpcSubnetRange")
-    def dr_vpc_subnet_range(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dr_vpc_subnet_range(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The VPC subnet range for the Disaster Recovery region. Only valid when `is_dr_enabled` is true. Cannot be changed once set.
         """
         return pulumi.get(self, "dr_vpc_subnet_range")
 
     @dr_vpc_subnet_range.setter
-    def dr_vpc_subnet_range(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dr_vpc_subnet_range(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dr_vpc_subnet_range", value)
 
     @_builtins.property
     @pulumi.getter(name="enableReplicationTimeControl")
-    def enable_replication_time_control(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def enable_replication_time_control(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether to enable S3 Replication Time Control for Disaster Recovery. Only valid when `is_dr_enabled` is true (AWS only).
         """
         return pulumi.get(self, "enable_replication_time_control")
 
     @enable_replication_time_control.setter
-    def enable_replication_time_control(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def enable_replication_time_control(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "enable_replication_time_control", value)
 
     @_builtins.property
     @pulumi.getter(name="isDrEnabled")
-    def is_dr_enabled(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_dr_enabled(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether Disaster Recovery is enabled on the cluster. Only supported for AWS clusters. Can only be enabled at cluster creation time. Can be set to `false` to disable DR on an existing cluster.
         """
         return pulumi.get(self, "is_dr_enabled")
 
     @is_dr_enabled.setter
-    def is_dr_enabled(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_dr_enabled(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_dr_enabled", value)
 
     @_builtins.property
     @pulumi.getter(name="isFailedOver")
-    def is_failed_over(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_failed_over(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether the cluster is currently failed over to the DR region. Set to `true` to trigger failover; set to `false` to fail back.
         """
         return pulumi.get(self, "is_failed_over")
 
     @is_failed_over.setter
-    def is_failed_over(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_failed_over(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_failed_over", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter(name="podSubnetRange")
-    def pod_subnet_range(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def pod_subnet_range(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster pod subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
         """
         return pulumi.get(self, "pod_subnet_range")
 
     @pod_subnet_range.setter
-    def pod_subnet_range(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def pod_subnet_range(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "pod_subnet_range", value)
 
     @_builtins.property
     @pulumi.getter(name="servicePeeringRange")
-    def service_peering_range(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def service_peering_range(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster service peering range - required for 'GCP' clusters. If changed, the cluster will be recreated.
         """
         return pulumi.get(self, "service_peering_range")
 
     @service_peering_range.setter
-    def service_peering_range(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def service_peering_range(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "service_peering_range", value)
 
     @_builtins.property
     @pulumi.getter(name="serviceSubnetRange")
-    def service_subnet_range(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def service_subnet_range(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster service subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
         """
         return pulumi.get(self, "service_subnet_range")
 
     @service_subnet_range.setter
-    def service_subnet_range(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def service_subnet_range(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "service_subnet_range", value)
 
     @_builtins.property
     @pulumi.getter
-    def timeouts(self) -> Optional[pulumi.Input['ClusterTimeoutsArgs']]:
+    def timeouts(self) -> pulumi.Input[Optional['ClusterTimeoutsArgs']]:
         return pulumi.get(self, "timeouts")
 
     @timeouts.setter
-    def timeouts(self, value: Optional[pulumi.Input['ClusterTimeoutsArgs']]):
+    def timeouts(self, value: pulumi.Input[Optional['ClusterTimeoutsArgs']]):
         pulumi.set(self, "timeouts", value)
 
 
 @pulumi.input_type
 class _ClusterState:
     def __init__(__self__, *,
-                 cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 db_instance_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_region: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_secondary_vpc_cidr: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_vpc_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 enable_replication_time_control: Optional[pulumi.Input[_builtins.bool]] = None,
-                 health_status: Optional[pulumi.Input['ClusterHealthStatusArgs']] = None,
-                 is_dr_enabled: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_failed_over: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_limited: Optional[pulumi.Input[_builtins.bool]] = None,
-                 metadata: Optional[pulumi.Input['ClusterMetadataArgs']] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 node_pools: Optional[pulumi.Input[Sequence[pulumi.Input['ClusterNodePoolArgs']]]] = None,
-                 pod_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 provider_account: Optional[pulumi.Input[_builtins.str]] = None,
-                 region: Optional[pulumi.Input[_builtins.str]] = None,
-                 service_peering_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 service_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 status: Optional[pulumi.Input[_builtins.str]] = None,
-                 tenant_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 timeouts: Optional[pulumi.Input['ClusterTimeoutsArgs']] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 vpc_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None):
+                 cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 db_instance_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_region: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_secondary_vpc_cidr: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_vpc_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 enable_replication_time_control: pulumi.Input[Optional[_builtins.bool]] = None,
+                 health_status: pulumi.Input[Optional['ClusterHealthStatusArgs']] = None,
+                 is_dr_enabled: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_failed_over: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_limited: pulumi.Input[Optional[_builtins.bool]] = None,
+                 metadata: pulumi.Input[Optional['ClusterMetadataArgs']] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 node_pools: pulumi.Input[Optional[Sequence[pulumi.Input['ClusterNodePoolArgs']]]] = None,
+                 pod_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 provider_account: pulumi.Input[Optional[_builtins.str]] = None,
+                 region: pulumi.Input[Optional[_builtins.str]] = None,
+                 service_peering_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 service_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 status: pulumi.Input[Optional[_builtins.str]] = None,
+                 tenant_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 timeouts: pulumi.Input[Optional['ClusterTimeoutsArgs']] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 vpc_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None):
         """
         Input properties used for looking up and filtering Cluster resources.
 
@@ -387,311 +387,311 @@ class _ClusterState:
 
     @_builtins.property
     @pulumi.getter(name="cloudProvider")
-    def cloud_provider(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def cloud_provider(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster cloud provider - if changed, the cluster will be recreated. Allowed values: `AWS`, `GCP`, `AZURE`.
         """
         return pulumi.get(self, "cloud_provider")
 
     @cloud_provider.setter
-    def cloud_provider(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def cloud_provider(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "cloud_provider", value)
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster creation timestamp
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter(name="dbInstanceType")
-    def db_instance_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def db_instance_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster database instance type
         """
         return pulumi.get(self, "db_instance_type")
 
     @db_instance_type.setter
-    def db_instance_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def db_instance_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "db_instance_type", value)
 
     @_builtins.property
     @pulumi.getter(name="drRegion")
-    def dr_region(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dr_region(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The secondary region for Disaster Recovery. Required when `is_dr_enabled` is true. Cannot be changed once set.
         """
         return pulumi.get(self, "dr_region")
 
     @dr_region.setter
-    def dr_region(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dr_region(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dr_region", value)
 
     @_builtins.property
     @pulumi.getter(name="drSecondaryVpcCidr")
-    def dr_secondary_vpc_cidr(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dr_secondary_vpc_cidr(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Secondary CIDR for pod networking in the DR region (AWS only). Cannot be changed once set.
         """
         return pulumi.get(self, "dr_secondary_vpc_cidr")
 
     @dr_secondary_vpc_cidr.setter
-    def dr_secondary_vpc_cidr(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dr_secondary_vpc_cidr(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dr_secondary_vpc_cidr", value)
 
     @_builtins.property
     @pulumi.getter(name="drVpcSubnetRange")
-    def dr_vpc_subnet_range(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dr_vpc_subnet_range(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The VPC subnet range for the Disaster Recovery region. Only valid when `is_dr_enabled` is true. Cannot be changed once set.
         """
         return pulumi.get(self, "dr_vpc_subnet_range")
 
     @dr_vpc_subnet_range.setter
-    def dr_vpc_subnet_range(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dr_vpc_subnet_range(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dr_vpc_subnet_range", value)
 
     @_builtins.property
     @pulumi.getter(name="enableReplicationTimeControl")
-    def enable_replication_time_control(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def enable_replication_time_control(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether to enable S3 Replication Time Control for Disaster Recovery. Only valid when `is_dr_enabled` is true (AWS only).
         """
         return pulumi.get(self, "enable_replication_time_control")
 
     @enable_replication_time_control.setter
-    def enable_replication_time_control(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def enable_replication_time_control(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "enable_replication_time_control", value)
 
     @_builtins.property
     @pulumi.getter(name="healthStatus")
-    def health_status(self) -> Optional[pulumi.Input['ClusterHealthStatusArgs']]:
+    def health_status(self) -> pulumi.Input[Optional['ClusterHealthStatusArgs']]:
         """
         Cluster health status
         """
         return pulumi.get(self, "health_status")
 
     @health_status.setter
-    def health_status(self, value: Optional[pulumi.Input['ClusterHealthStatusArgs']]):
+    def health_status(self, value: pulumi.Input[Optional['ClusterHealthStatusArgs']]):
         pulumi.set(self, "health_status", value)
 
     @_builtins.property
     @pulumi.getter(name="isDrEnabled")
-    def is_dr_enabled(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_dr_enabled(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether Disaster Recovery is enabled on the cluster. Only supported for AWS clusters. Can only be enabled at cluster creation time. Can be set to `false` to disable DR on an existing cluster.
         """
         return pulumi.get(self, "is_dr_enabled")
 
     @is_dr_enabled.setter
-    def is_dr_enabled(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_dr_enabled(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_dr_enabled", value)
 
     @_builtins.property
     @pulumi.getter(name="isFailedOver")
-    def is_failed_over(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_failed_over(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether the cluster is currently failed over to the DR region. Set to `true` to trigger failover; set to `false` to fail back.
         """
         return pulumi.get(self, "is_failed_over")
 
     @is_failed_over.setter
-    def is_failed_over(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_failed_over(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_failed_over", value)
 
     @_builtins.property
     @pulumi.getter(name="isLimited")
-    def is_limited(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_limited(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether the cluster is limited
         """
         return pulumi.get(self, "is_limited")
 
     @is_limited.setter
-    def is_limited(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_limited(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_limited", value)
 
     @_builtins.property
     @pulumi.getter
-    def metadata(self) -> Optional[pulumi.Input['ClusterMetadataArgs']]:
+    def metadata(self) -> pulumi.Input[Optional['ClusterMetadataArgs']]:
         """
         Cluster metadata
         """
         return pulumi.get(self, "metadata")
 
     @metadata.setter
-    def metadata(self, value: Optional[pulumi.Input['ClusterMetadataArgs']]):
+    def metadata(self, value: pulumi.Input[Optional['ClusterMetadataArgs']]):
         pulumi.set(self, "metadata", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter(name="nodePools")
-    def node_pools(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['ClusterNodePoolArgs']]]]:
+    def node_pools(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['ClusterNodePoolArgs']]]]:
         """
         Cluster node pools
         """
         return pulumi.get(self, "node_pools")
 
     @node_pools.setter
-    def node_pools(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ClusterNodePoolArgs']]]]):
+    def node_pools(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['ClusterNodePoolArgs']]]]):
         pulumi.set(self, "node_pools", value)
 
     @_builtins.property
     @pulumi.getter(name="podSubnetRange")
-    def pod_subnet_range(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def pod_subnet_range(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster pod subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
         """
         return pulumi.get(self, "pod_subnet_range")
 
     @pod_subnet_range.setter
-    def pod_subnet_range(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def pod_subnet_range(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "pod_subnet_range", value)
 
     @_builtins.property
     @pulumi.getter(name="providerAccount")
-    def provider_account(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def provider_account(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster provider account
         """
         return pulumi.get(self, "provider_account")
 
     @provider_account.setter
-    def provider_account(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def provider_account(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "provider_account", value)
 
     @_builtins.property
     @pulumi.getter
-    def region(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def region(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster region - if changed, the cluster will be recreated.
         """
         return pulumi.get(self, "region")
 
     @region.setter
-    def region(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def region(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "region", value)
 
     @_builtins.property
     @pulumi.getter(name="servicePeeringRange")
-    def service_peering_range(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def service_peering_range(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster service peering range - required for 'GCP' clusters. If changed, the cluster will be recreated.
         """
         return pulumi.get(self, "service_peering_range")
 
     @service_peering_range.setter
-    def service_peering_range(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def service_peering_range(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "service_peering_range", value)
 
     @_builtins.property
     @pulumi.getter(name="serviceSubnetRange")
-    def service_subnet_range(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def service_subnet_range(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster service subnet range - required for 'GCP' clusters. If changed, the cluster will be recreated.
         """
         return pulumi.get(self, "service_subnet_range")
 
     @service_subnet_range.setter
-    def service_subnet_range(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def service_subnet_range(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "service_subnet_range", value)
 
     @_builtins.property
     @pulumi.getter
-    def status(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def status(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster status
         """
         return pulumi.get(self, "status")
 
     @status.setter
-    def status(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def status(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "status", value)
 
     @_builtins.property
     @pulumi.getter(name="tenantId")
-    def tenant_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def tenant_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster tenant ID
         """
         return pulumi.get(self, "tenant_id")
 
     @tenant_id.setter
-    def tenant_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def tenant_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "tenant_id", value)
 
     @_builtins.property
     @pulumi.getter
-    def timeouts(self) -> Optional[pulumi.Input['ClusterTimeoutsArgs']]:
+    def timeouts(self) -> pulumi.Input[Optional['ClusterTimeoutsArgs']]:
         return pulumi.get(self, "timeouts")
 
     @timeouts.setter
-    def timeouts(self, value: Optional[pulumi.Input['ClusterTimeoutsArgs']]):
+    def timeouts(self, value: pulumi.Input[Optional['ClusterTimeoutsArgs']]):
         pulumi.set(self, "timeouts", value)
 
     @_builtins.property
     @pulumi.getter
-    def type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster type
         """
         return pulumi.get(self, "type")
 
     @type.setter
-    def type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "type", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter(name="vpcSubnetRange")
-    def vpc_subnet_range(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def vpc_subnet_range(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Cluster VPC subnet range. If changed, the cluster will be recreated.
         """
         return pulumi.get(self, "vpc_subnet_range")
 
     @vpc_subnet_range.setter
-    def vpc_subnet_range(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def vpc_subnet_range(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "vpc_subnet_range", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceIds")
-    def workspace_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def workspace_ids(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         Cluster workspace IDs
         """
         return pulumi.get(self, "workspace_ids")
 
     @workspace_ids.setter
-    def workspace_ids(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def workspace_ids(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "workspace_ids", value)
 
 
@@ -701,22 +701,22 @@ class Cluster(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_region: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_secondary_vpc_cidr: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_vpc_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 enable_replication_time_control: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_dr_enabled: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_failed_over: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 pod_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 region: Optional[pulumi.Input[_builtins.str]] = None,
-                 service_peering_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 service_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 timeouts: Optional[pulumi.Input[Union['ClusterTimeoutsArgs', 'ClusterTimeoutsArgsDict']]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
-                 vpc_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_region: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_secondary_vpc_cidr: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_vpc_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 enable_replication_time_control: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_dr_enabled: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_failed_over: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 pod_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 region: pulumi.Input[Optional[_builtins.str]] = None,
+                 service_peering_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 service_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 timeouts: pulumi.Input[Optional[Union['ClusterTimeoutsArgs', 'ClusterTimeoutsArgsDict']]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
+                 vpc_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  __props__=None):
         """
         Cluster resource. If creating multiple clusters, add a delay between each cluster creation to avoid cluster creation limiting errors.
@@ -765,22 +765,22 @@ class Cluster(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_region: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_secondary_vpc_cidr: Optional[pulumi.Input[_builtins.str]] = None,
-                 dr_vpc_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 enable_replication_time_control: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_dr_enabled: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_failed_over: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 pod_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 region: Optional[pulumi.Input[_builtins.str]] = None,
-                 service_peering_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 service_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 timeouts: Optional[pulumi.Input[Union['ClusterTimeoutsArgs', 'ClusterTimeoutsArgsDict']]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
-                 vpc_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_region: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_secondary_vpc_cidr: pulumi.Input[Optional[_builtins.str]] = None,
+                 dr_vpc_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 enable_replication_time_control: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_dr_enabled: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_failed_over: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 pod_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 region: pulumi.Input[Optional[_builtins.str]] = None,
+                 service_peering_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 service_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 timeouts: pulumi.Input[Optional[Union['ClusterTimeoutsArgs', 'ClusterTimeoutsArgsDict']]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
+                 vpc_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -836,32 +836,32 @@ class Cluster(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-            created_at: Optional[pulumi.Input[_builtins.str]] = None,
-            db_instance_type: Optional[pulumi.Input[_builtins.str]] = None,
-            dr_region: Optional[pulumi.Input[_builtins.str]] = None,
-            dr_secondary_vpc_cidr: Optional[pulumi.Input[_builtins.str]] = None,
-            dr_vpc_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-            enable_replication_time_control: Optional[pulumi.Input[_builtins.bool]] = None,
-            health_status: Optional[pulumi.Input[Union['ClusterHealthStatusArgs', 'ClusterHealthStatusArgsDict']]] = None,
-            is_dr_enabled: Optional[pulumi.Input[_builtins.bool]] = None,
-            is_failed_over: Optional[pulumi.Input[_builtins.bool]] = None,
-            is_limited: Optional[pulumi.Input[_builtins.bool]] = None,
-            metadata: Optional[pulumi.Input[Union['ClusterMetadataArgs', 'ClusterMetadataArgsDict']]] = None,
-            name: Optional[pulumi.Input[_builtins.str]] = None,
-            node_pools: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterNodePoolArgs', 'ClusterNodePoolArgsDict']]]]] = None,
-            pod_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-            provider_account: Optional[pulumi.Input[_builtins.str]] = None,
-            region: Optional[pulumi.Input[_builtins.str]] = None,
-            service_peering_range: Optional[pulumi.Input[_builtins.str]] = None,
-            service_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-            status: Optional[pulumi.Input[_builtins.str]] = None,
-            tenant_id: Optional[pulumi.Input[_builtins.str]] = None,
-            timeouts: Optional[pulumi.Input[Union['ClusterTimeoutsArgs', 'ClusterTimeoutsArgsDict']]] = None,
-            type: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-            vpc_subnet_range: Optional[pulumi.Input[_builtins.str]] = None,
-            workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None) -> 'Cluster':
+            cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+            created_at: pulumi.Input[Optional[_builtins.str]] = None,
+            db_instance_type: pulumi.Input[Optional[_builtins.str]] = None,
+            dr_region: pulumi.Input[Optional[_builtins.str]] = None,
+            dr_secondary_vpc_cidr: pulumi.Input[Optional[_builtins.str]] = None,
+            dr_vpc_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+            enable_replication_time_control: pulumi.Input[Optional[_builtins.bool]] = None,
+            health_status: pulumi.Input[Optional[Union['ClusterHealthStatusArgs', 'ClusterHealthStatusArgsDict']]] = None,
+            is_dr_enabled: pulumi.Input[Optional[_builtins.bool]] = None,
+            is_failed_over: pulumi.Input[Optional[_builtins.bool]] = None,
+            is_limited: pulumi.Input[Optional[_builtins.bool]] = None,
+            metadata: pulumi.Input[Optional[Union['ClusterMetadataArgs', 'ClusterMetadataArgsDict']]] = None,
+            name: pulumi.Input[Optional[_builtins.str]] = None,
+            node_pools: pulumi.Input[Optional[Sequence[pulumi.Input[Union['ClusterNodePoolArgs', 'ClusterNodePoolArgsDict']]]]] = None,
+            pod_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+            provider_account: pulumi.Input[Optional[_builtins.str]] = None,
+            region: pulumi.Input[Optional[_builtins.str]] = None,
+            service_peering_range: pulumi.Input[Optional[_builtins.str]] = None,
+            service_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+            status: pulumi.Input[Optional[_builtins.str]] = None,
+            tenant_id: pulumi.Input[Optional[_builtins.str]] = None,
+            timeouts: pulumi.Input[Optional[Union['ClusterTimeoutsArgs', 'ClusterTimeoutsArgsDict']]] = None,
+            type: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+            vpc_subnet_range: pulumi.Input[Optional[_builtins.str]] = None,
+            workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None) -> 'Cluster':
         """
         Get an existing Cluster resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/custom_role.py
+++ b/sdk/python/pulumi_astronomer/custom_role.py
@@ -23,9 +23,9 @@ class CustomRoleArgs:
     def __init__(__self__, *,
                  permissions: pulumi.Input[Sequence[pulumi.Input[_builtins.str]]],
                  scope_type: pulumi.Input[_builtins.str],
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 restricted_workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None):
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 restricted_workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None):
         """
         The set of arguments for constructing a CustomRole resource.
 
@@ -70,53 +70,53 @@ class CustomRoleArgs:
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The custom role's description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The custom role's name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter(name="restrictedWorkspaceIds")
-    def restricted_workspace_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def restricted_workspace_ids(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The IDs of Workspaces that the custom role is restricted to
         """
         return pulumi.get(self, "restricted_workspace_ids")
 
     @restricted_workspace_ids.setter
-    def restricted_workspace_ids(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def restricted_workspace_ids(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "restricted_workspace_ids", value)
 
 
 @pulumi.input_type
 class _CustomRoleState:
     def __init__(__self__, *,
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_by: Optional[pulumi.Input['CustomRoleCreatedByArgs']] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 permissions: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 restricted_workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 scope_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_by: Optional[pulumi.Input['CustomRoleUpdatedByArgs']] = None):
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_by: pulumi.Input[Optional['CustomRoleCreatedByArgs']] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 permissions: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 restricted_workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 scope_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_by: pulumi.Input[Optional['CustomRoleUpdatedByArgs']] = None):
         """
         Input properties used for looking up and filtering CustomRole resources.
 
@@ -151,110 +151,110 @@ class _CustomRoleState:
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The time the custom role was created
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter(name="createdBy")
-    def created_by(self) -> Optional[pulumi.Input['CustomRoleCreatedByArgs']]:
+    def created_by(self) -> pulumi.Input[Optional['CustomRoleCreatedByArgs']]:
         """
         The subject who created the custom role
         """
         return pulumi.get(self, "created_by")
 
     @created_by.setter
-    def created_by(self, value: Optional[pulumi.Input['CustomRoleCreatedByArgs']]):
+    def created_by(self, value: pulumi.Input[Optional['CustomRoleCreatedByArgs']]):
         pulumi.set(self, "created_by", value)
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The custom role's description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The custom role's name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter
-    def permissions(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def permissions(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The custom role's permissions
         """
         return pulumi.get(self, "permissions")
 
     @permissions.setter
-    def permissions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def permissions(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "permissions", value)
 
     @_builtins.property
     @pulumi.getter(name="restrictedWorkspaceIds")
-    def restricted_workspace_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def restricted_workspace_ids(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The IDs of Workspaces that the custom role is restricted to
         """
         return pulumi.get(self, "restricted_workspace_ids")
 
     @restricted_workspace_ids.setter
-    def restricted_workspace_ids(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def restricted_workspace_ids(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "restricted_workspace_ids", value)
 
     @_builtins.property
     @pulumi.getter(name="scopeType")
-    def scope_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def scope_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The custom role's scope (DEPLOYMENT or DAG)
         """
         return pulumi.get(self, "scope_type")
 
     @scope_type.setter
-    def scope_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def scope_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "scope_type", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The time the custom role was last updated
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedBy")
-    def updated_by(self) -> Optional[pulumi.Input['CustomRoleUpdatedByArgs']]:
+    def updated_by(self) -> pulumi.Input[Optional['CustomRoleUpdatedByArgs']]:
         """
         The subject who last updated the custom role
         """
         return pulumi.get(self, "updated_by")
 
     @updated_by.setter
-    def updated_by(self, value: Optional[pulumi.Input['CustomRoleUpdatedByArgs']]):
+    def updated_by(self, value: pulumi.Input[Optional['CustomRoleUpdatedByArgs']]):
         pulumi.set(self, "updated_by", value)
 
 
@@ -264,11 +264,11 @@ class CustomRole(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 permissions: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 restricted_workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 scope_type: Optional[pulumi.Input[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 permissions: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 restricted_workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 scope_type: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         Custom role resource
@@ -359,11 +359,11 @@ class CustomRole(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 permissions: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 restricted_workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 scope_type: Optional[pulumi.Input[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 permissions: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 restricted_workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 scope_type: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -396,15 +396,15 @@ class CustomRole(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            created_at: Optional[pulumi.Input[_builtins.str]] = None,
-            created_by: Optional[pulumi.Input[Union['CustomRoleCreatedByArgs', 'CustomRoleCreatedByArgsDict']]] = None,
-            description: Optional[pulumi.Input[_builtins.str]] = None,
-            name: Optional[pulumi.Input[_builtins.str]] = None,
-            permissions: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-            restricted_workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-            scope_type: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_by: Optional[pulumi.Input[Union['CustomRoleUpdatedByArgs', 'CustomRoleUpdatedByArgsDict']]] = None) -> 'CustomRole':
+            created_at: pulumi.Input[Optional[_builtins.str]] = None,
+            created_by: pulumi.Input[Optional[Union['CustomRoleCreatedByArgs', 'CustomRoleCreatedByArgsDict']]] = None,
+            description: pulumi.Input[Optional[_builtins.str]] = None,
+            name: pulumi.Input[Optional[_builtins.str]] = None,
+            permissions: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+            restricted_workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+            scope_type: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_by: pulumi.Input[Optional[Union['CustomRoleUpdatedByArgs', 'CustomRoleUpdatedByArgsDict']]] = None) -> 'CustomRole':
         """
         Get an existing CustomRole resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/deployment.py
+++ b/sdk/python/pulumi_astronomer/deployment.py
@@ -29,25 +29,25 @@ class DeploymentArgs:
                  is_dag_deploy_enabled: pulumi.Input[_builtins.bool],
                  type: pulumi.Input[_builtins.str],
                  workspace_id: pulumi.Input[_builtins.str],
-                 cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-                 cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 default_task_pod_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 default_task_pod_memory: Optional[pulumi.Input[_builtins.str]] = None,
-                 desired_workload_identity: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_development_mode: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_high_availability: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 original_astro_runtime_version: Optional[pulumi.Input[_builtins.str]] = None,
-                 region: Optional[pulumi.Input[_builtins.str]] = None,
-                 remote_execution: Optional[pulumi.Input['DeploymentRemoteExecutionArgs']] = None,
-                 resource_quota_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 resource_quota_memory: Optional[pulumi.Input[_builtins.str]] = None,
-                 scaling_spec: Optional[pulumi.Input['DeploymentScalingSpecArgs']] = None,
-                 scheduler_au: Optional[pulumi.Input[_builtins.int]] = None,
-                 scheduler_replicas: Optional[pulumi.Input[_builtins.int]] = None,
-                 scheduler_size: Optional[pulumi.Input[_builtins.str]] = None,
-                 task_pod_node_pool_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 worker_queues: Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]] = None):
+                 cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+                 cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 default_task_pod_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 default_task_pod_memory: pulumi.Input[Optional[_builtins.str]] = None,
+                 desired_workload_identity: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_development_mode: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_high_availability: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 original_astro_runtime_version: pulumi.Input[Optional[_builtins.str]] = None,
+                 region: pulumi.Input[Optional[_builtins.str]] = None,
+                 remote_execution: pulumi.Input[Optional['DeploymentRemoteExecutionArgs']] = None,
+                 resource_quota_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 resource_quota_memory: pulumi.Input[Optional[_builtins.str]] = None,
+                 scaling_spec: pulumi.Input[Optional['DeploymentScalingSpecArgs']] = None,
+                 scheduler_au: pulumi.Input[Optional[_builtins.int]] = None,
+                 scheduler_replicas: pulumi.Input[Optional[_builtins.int]] = None,
+                 scheduler_size: pulumi.Input[Optional[_builtins.str]] = None,
+                 task_pod_node_pool_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 worker_queues: pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]] = None):
         """
         The set of arguments for constructing a Deployment resource.
 
@@ -224,286 +224,286 @@ class DeploymentArgs:
 
     @_builtins.property
     @pulumi.getter(name="cloudProvider")
-    def cloud_provider(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def cloud_provider(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment cloud provider - required for 'STANDARD' deployments. If changing this value, the deployment will be recreated in the new cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
         """
         return pulumi.get(self, "cloud_provider")
 
     @cloud_provider.setter
-    def cloud_provider(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def cloud_provider(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "cloud_provider", value)
 
     @_builtins.property
     @pulumi.getter(name="clusterId")
-    def cluster_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def cluster_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment cluster identifier - required for 'HYBRID' and 'DEDICATED' deployments. If changing this value, the deployment will be recreated in the new cluster
         """
         return pulumi.get(self, "cluster_id")
 
     @cluster_id.setter
-    def cluster_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def cluster_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "cluster_id", value)
 
     @_builtins.property
     @pulumi.getter(name="defaultTaskPodCpu")
-    def default_task_pod_cpu(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def default_task_pod_cpu(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment default task pod CPU - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "default_task_pod_cpu")
 
     @default_task_pod_cpu.setter
-    def default_task_pod_cpu(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def default_task_pod_cpu(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "default_task_pod_cpu", value)
 
     @_builtins.property
     @pulumi.getter(name="defaultTaskPodMemory")
-    def default_task_pod_memory(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def default_task_pod_memory(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment default task pod memory - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "default_task_pod_memory")
 
     @default_task_pod_memory.setter
-    def default_task_pod_memory(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def default_task_pod_memory(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "default_task_pod_memory", value)
 
     @_builtins.property
     @pulumi.getter(name="desiredWorkloadIdentity")
-    def desired_workload_identity(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def desired_workload_identity(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment's desired workload identity. The Terraform provider will use this provided workload identity to create the Deployment. If it is not provided the workload identity will be assigned automatically.
         """
         return pulumi.get(self, "desired_workload_identity")
 
     @desired_workload_identity.setter
-    def desired_workload_identity(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def desired_workload_identity(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "desired_workload_identity", value)
 
     @_builtins.property
     @pulumi.getter(name="isDevelopmentMode")
-    def is_development_mode(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_development_mode(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Deployment development mode - required for 'STANDARD' and 'DEDICATED' deployments. If changing from 'False' to 'True', the deployment will be recreated
         """
         return pulumi.get(self, "is_development_mode")
 
     @is_development_mode.setter
-    def is_development_mode(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_development_mode(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_development_mode", value)
 
     @_builtins.property
     @pulumi.getter(name="isHighAvailability")
-    def is_high_availability(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_high_availability(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Deployment high availability - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "is_high_availability")
 
     @is_high_availability.setter
-    def is_high_availability(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_high_availability(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_high_availability", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter(name="originalAstroRuntimeVersion")
-    def original_astro_runtime_version(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def original_astro_runtime_version(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment's original Astro Runtime version. The Terraform provider will use this provided Astro runtime version to create the Deployment. If not provided, defaults to the current Astro runtime version. The Astro runtime version can be updated with your Astro project Dockerfile, but if this value is changed, the Deployment will be recreated with this new Astro runtime version.
         """
         return pulumi.get(self, "original_astro_runtime_version")
 
     @original_astro_runtime_version.setter
-    def original_astro_runtime_version(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def original_astro_runtime_version(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "original_astro_runtime_version", value)
 
     @_builtins.property
     @pulumi.getter
-    def region(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def region(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment region - required for 'STANDARD' deployments. If changing this value, the deployment will be recreated in the new region
         """
         return pulumi.get(self, "region")
 
     @region.setter
-    def region(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def region(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "region", value)
 
     @_builtins.property
     @pulumi.getter(name="remoteExecution")
-    def remote_execution(self) -> Optional[pulumi.Input['DeploymentRemoteExecutionArgs']]:
+    def remote_execution(self) -> pulumi.Input[Optional['DeploymentRemoteExecutionArgs']]:
         """
         Deployment remote execution configuration - only for 'DEDICATED' deployments
         """
         return pulumi.get(self, "remote_execution")
 
     @remote_execution.setter
-    def remote_execution(self, value: Optional[pulumi.Input['DeploymentRemoteExecutionArgs']]):
+    def remote_execution(self, value: pulumi.Input[Optional['DeploymentRemoteExecutionArgs']]):
         pulumi.set(self, "remote_execution", value)
 
     @_builtins.property
     @pulumi.getter(name="resourceQuotaCpu")
-    def resource_quota_cpu(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def resource_quota_cpu(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment resource quota CPU - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "resource_quota_cpu")
 
     @resource_quota_cpu.setter
-    def resource_quota_cpu(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def resource_quota_cpu(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "resource_quota_cpu", value)
 
     @_builtins.property
     @pulumi.getter(name="resourceQuotaMemory")
-    def resource_quota_memory(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def resource_quota_memory(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment resource quota memory - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "resource_quota_memory")
 
     @resource_quota_memory.setter
-    def resource_quota_memory(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def resource_quota_memory(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "resource_quota_memory", value)
 
     @_builtins.property
     @pulumi.getter(name="scalingSpec")
-    def scaling_spec(self) -> Optional[pulumi.Input['DeploymentScalingSpecArgs']]:
+    def scaling_spec(self) -> pulumi.Input[Optional['DeploymentScalingSpecArgs']]:
         """
         Deployment scaling spec - only for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "scaling_spec")
 
     @scaling_spec.setter
-    def scaling_spec(self, value: Optional[pulumi.Input['DeploymentScalingSpecArgs']]):
+    def scaling_spec(self, value: pulumi.Input[Optional['DeploymentScalingSpecArgs']]):
         pulumi.set(self, "scaling_spec", value)
 
     @_builtins.property
     @pulumi.getter(name="schedulerAu")
-    def scheduler_au(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def scheduler_au(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         Deployment scheduler AU - required for 'HYBRID' deployments
         """
         return pulumi.get(self, "scheduler_au")
 
     @scheduler_au.setter
-    def scheduler_au(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def scheduler_au(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "scheduler_au", value)
 
     @_builtins.property
     @pulumi.getter(name="schedulerReplicas")
-    def scheduler_replicas(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def scheduler_replicas(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         Deployment scheduler replicas - required for 'HYBRID' deployments
         """
         return pulumi.get(self, "scheduler_replicas")
 
     @scheduler_replicas.setter
-    def scheduler_replicas(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def scheduler_replicas(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "scheduler_replicas", value)
 
     @_builtins.property
     @pulumi.getter(name="schedulerSize")
-    def scheduler_size(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def scheduler_size(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment scheduler size - required for 'STANDARD' and 'DEDICATED' deployments. Allowed values: `SMALL`, `MEDIUM`, `LARGE`, `EXTRALARGE`.
         """
         return pulumi.get(self, "scheduler_size")
 
     @scheduler_size.setter
-    def scheduler_size(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def scheduler_size(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "scheduler_size", value)
 
     @_builtins.property
     @pulumi.getter(name="taskPodNodePoolId")
-    def task_pod_node_pool_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def task_pod_node_pool_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment task pod node pool identifier - required if executor is 'KUBERNETES' and type is 'HYBRID'
         """
         return pulumi.get(self, "task_pod_node_pool_id")
 
     @task_pod_node_pool_id.setter
-    def task_pod_node_pool_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def task_pod_node_pool_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "task_pod_node_pool_id", value)
 
     @_builtins.property
     @pulumi.getter(name="workerQueues")
-    def worker_queues(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]]:
+    def worker_queues(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]]:
         """
         Deployment worker queues - required for deployments with 'CELERY' executor. For 'STANDARD' and 'DEDICATED' deployments, use astro*machine. For 'HYBRID' deployments, use node*pool*id.
         """
         return pulumi.get(self, "worker_queues")
 
     @worker_queues.setter
-    def worker_queues(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]]):
+    def worker_queues(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]]):
         pulumi.set(self, "worker_queues", value)
 
 
 @pulumi.input_type
 class _DeploymentState:
     def __init__(__self__, *,
-                 airflow_version: Optional[pulumi.Input[_builtins.str]] = None,
-                 astro_runtime_version: Optional[pulumi.Input[_builtins.str]] = None,
-                 cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-                 cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 contact_emails: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_by: Optional[pulumi.Input['DeploymentCreatedByArgs']] = None,
-                 dag_tarball_version: Optional[pulumi.Input[_builtins.str]] = None,
-                 default_task_pod_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 default_task_pod_memory: Optional[pulumi.Input[_builtins.str]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 desired_dag_tarball_version: Optional[pulumi.Input[_builtins.str]] = None,
-                 desired_workload_identity: Optional[pulumi.Input[_builtins.str]] = None,
-                 environment_variables: Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentEnvironmentVariableArgs']]]] = None,
-                 executor: Optional[pulumi.Input[_builtins.str]] = None,
-                 external_ips: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 image_repository: Optional[pulumi.Input[_builtins.str]] = None,
-                 image_tag: Optional[pulumi.Input[_builtins.str]] = None,
-                 image_version: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_cicd_enforced: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_dag_deploy_enabled: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_development_mode: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_high_availability: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 namespace: Optional[pulumi.Input[_builtins.str]] = None,
-                 oidc_issuer_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 original_astro_runtime_version: Optional[pulumi.Input[_builtins.str]] = None,
-                 region: Optional[pulumi.Input[_builtins.str]] = None,
-                 remote_execution: Optional[pulumi.Input['DeploymentRemoteExecutionArgs']] = None,
-                 resource_quota_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 resource_quota_memory: Optional[pulumi.Input[_builtins.str]] = None,
-                 scaling_spec: Optional[pulumi.Input['DeploymentScalingSpecArgs']] = None,
-                 scaling_status: Optional[pulumi.Input['DeploymentScalingStatusArgs']] = None,
-                 scheduler_au: Optional[pulumi.Input[_builtins.int]] = None,
-                 scheduler_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 scheduler_memory: Optional[pulumi.Input[_builtins.str]] = None,
-                 scheduler_replicas: Optional[pulumi.Input[_builtins.int]] = None,
-                 scheduler_size: Optional[pulumi.Input[_builtins.str]] = None,
-                 status: Optional[pulumi.Input[_builtins.str]] = None,
-                 status_reason: Optional[pulumi.Input[_builtins.str]] = None,
-                 task_pod_node_pool_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_by: Optional[pulumi.Input['DeploymentUpdatedByArgs']] = None,
-                 webserver_airflow_api_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 webserver_ingress_hostname: Optional[pulumi.Input[_builtins.str]] = None,
-                 webserver_url: Optional[pulumi.Input[_builtins.str]] = None,
-                 worker_queues: Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]] = None,
-                 workload_identity: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_id: Optional[pulumi.Input[_builtins.str]] = None):
+                 airflow_version: pulumi.Input[Optional[_builtins.str]] = None,
+                 astro_runtime_version: pulumi.Input[Optional[_builtins.str]] = None,
+                 cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+                 cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 contact_emails: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_by: pulumi.Input[Optional['DeploymentCreatedByArgs']] = None,
+                 dag_tarball_version: pulumi.Input[Optional[_builtins.str]] = None,
+                 default_task_pod_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 default_task_pod_memory: pulumi.Input[Optional[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 desired_dag_tarball_version: pulumi.Input[Optional[_builtins.str]] = None,
+                 desired_workload_identity: pulumi.Input[Optional[_builtins.str]] = None,
+                 environment_variables: pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentEnvironmentVariableArgs']]]] = None,
+                 executor: pulumi.Input[Optional[_builtins.str]] = None,
+                 external_ips: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 image_repository: pulumi.Input[Optional[_builtins.str]] = None,
+                 image_tag: pulumi.Input[Optional[_builtins.str]] = None,
+                 image_version: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_cicd_enforced: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_dag_deploy_enabled: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_development_mode: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_high_availability: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 namespace: pulumi.Input[Optional[_builtins.str]] = None,
+                 oidc_issuer_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 original_astro_runtime_version: pulumi.Input[Optional[_builtins.str]] = None,
+                 region: pulumi.Input[Optional[_builtins.str]] = None,
+                 remote_execution: pulumi.Input[Optional['DeploymentRemoteExecutionArgs']] = None,
+                 resource_quota_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 resource_quota_memory: pulumi.Input[Optional[_builtins.str]] = None,
+                 scaling_spec: pulumi.Input[Optional['DeploymentScalingSpecArgs']] = None,
+                 scaling_status: pulumi.Input[Optional['DeploymentScalingStatusArgs']] = None,
+                 scheduler_au: pulumi.Input[Optional[_builtins.int]] = None,
+                 scheduler_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 scheduler_memory: pulumi.Input[Optional[_builtins.str]] = None,
+                 scheduler_replicas: pulumi.Input[Optional[_builtins.int]] = None,
+                 scheduler_size: pulumi.Input[Optional[_builtins.str]] = None,
+                 status: pulumi.Input[Optional[_builtins.str]] = None,
+                 status_reason: pulumi.Input[Optional[_builtins.str]] = None,
+                 task_pod_node_pool_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_by: pulumi.Input[Optional['DeploymentUpdatedByArgs']] = None,
+                 webserver_airflow_api_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 webserver_ingress_hostname: pulumi.Input[Optional[_builtins.str]] = None,
+                 webserver_url: pulumi.Input[Optional[_builtins.str]] = None,
+                 worker_queues: pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]] = None,
+                 workload_identity: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_id: pulumi.Input[Optional[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering Deployment resources.
 
@@ -661,602 +661,602 @@ class _DeploymentState:
 
     @_builtins.property
     @pulumi.getter(name="airflowVersion")
-    def airflow_version(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def airflow_version(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment Airflow version
         """
         return pulumi.get(self, "airflow_version")
 
     @airflow_version.setter
-    def airflow_version(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def airflow_version(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "airflow_version", value)
 
     @_builtins.property
     @pulumi.getter(name="astroRuntimeVersion")
-    def astro_runtime_version(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def astro_runtime_version(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment's current Astro Runtime version
         """
         return pulumi.get(self, "astro_runtime_version")
 
     @astro_runtime_version.setter
-    def astro_runtime_version(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def astro_runtime_version(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "astro_runtime_version", value)
 
     @_builtins.property
     @pulumi.getter(name="cloudProvider")
-    def cloud_provider(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def cloud_provider(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment cloud provider - required for 'STANDARD' deployments. If changing this value, the deployment will be recreated in the new cloud provider. Allowed values: `AWS`, `GCP`, `AZURE`.
         """
         return pulumi.get(self, "cloud_provider")
 
     @cloud_provider.setter
-    def cloud_provider(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def cloud_provider(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "cloud_provider", value)
 
     @_builtins.property
     @pulumi.getter(name="clusterId")
-    def cluster_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def cluster_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment cluster identifier - required for 'HYBRID' and 'DEDICATED' deployments. If changing this value, the deployment will be recreated in the new cluster
         """
         return pulumi.get(self, "cluster_id")
 
     @cluster_id.setter
-    def cluster_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def cluster_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "cluster_id", value)
 
     @_builtins.property
     @pulumi.getter(name="contactEmails")
-    def contact_emails(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def contact_emails(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         Deployment contact emails
         """
         return pulumi.get(self, "contact_emails")
 
     @contact_emails.setter
-    def contact_emails(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def contact_emails(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "contact_emails", value)
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment creation timestamp
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter(name="createdBy")
-    def created_by(self) -> Optional[pulumi.Input['DeploymentCreatedByArgs']]:
+    def created_by(self) -> pulumi.Input[Optional['DeploymentCreatedByArgs']]:
         """
         Deployment creator
         """
         return pulumi.get(self, "created_by")
 
     @created_by.setter
-    def created_by(self, value: Optional[pulumi.Input['DeploymentCreatedByArgs']]):
+    def created_by(self, value: pulumi.Input[Optional['DeploymentCreatedByArgs']]):
         pulumi.set(self, "created_by", value)
 
     @_builtins.property
     @pulumi.getter(name="dagTarballVersion")
-    def dag_tarball_version(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def dag_tarball_version(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment DAG tarball version
         """
         return pulumi.get(self, "dag_tarball_version")
 
     @dag_tarball_version.setter
-    def dag_tarball_version(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def dag_tarball_version(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "dag_tarball_version", value)
 
     @_builtins.property
     @pulumi.getter(name="defaultTaskPodCpu")
-    def default_task_pod_cpu(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def default_task_pod_cpu(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment default task pod CPU - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "default_task_pod_cpu")
 
     @default_task_pod_cpu.setter
-    def default_task_pod_cpu(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def default_task_pod_cpu(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "default_task_pod_cpu", value)
 
     @_builtins.property
     @pulumi.getter(name="defaultTaskPodMemory")
-    def default_task_pod_memory(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def default_task_pod_memory(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment default task pod memory - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "default_task_pod_memory")
 
     @default_task_pod_memory.setter
-    def default_task_pod_memory(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def default_task_pod_memory(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "default_task_pod_memory", value)
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter(name="desiredDagTarballVersion")
-    def desired_dag_tarball_version(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def desired_dag_tarball_version(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment desired DAG tarball version
         """
         return pulumi.get(self, "desired_dag_tarball_version")
 
     @desired_dag_tarball_version.setter
-    def desired_dag_tarball_version(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def desired_dag_tarball_version(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "desired_dag_tarball_version", value)
 
     @_builtins.property
     @pulumi.getter(name="desiredWorkloadIdentity")
-    def desired_workload_identity(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def desired_workload_identity(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment's desired workload identity. The Terraform provider will use this provided workload identity to create the Deployment. If it is not provided the workload identity will be assigned automatically.
         """
         return pulumi.get(self, "desired_workload_identity")
 
     @desired_workload_identity.setter
-    def desired_workload_identity(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def desired_workload_identity(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "desired_workload_identity", value)
 
     @_builtins.property
     @pulumi.getter(name="environmentVariables")
-    def environment_variables(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentEnvironmentVariableArgs']]]]:
+    def environment_variables(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentEnvironmentVariableArgs']]]]:
         """
         Deployment environment variables. When importing a deployment, you must include all environment variables in your configuration. Any variables not specified will be deleted on the next apply. Secret values must be re-entered as the API does not return them.
         """
         return pulumi.get(self, "environment_variables")
 
     @environment_variables.setter
-    def environment_variables(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentEnvironmentVariableArgs']]]]):
+    def environment_variables(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentEnvironmentVariableArgs']]]]):
         pulumi.set(self, "environment_variables", value)
 
     @_builtins.property
     @pulumi.getter
-    def executor(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def executor(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment executor. Allowed values: `CELERY`, `KUBERNETES`, `ASTRO`.
         """
         return pulumi.get(self, "executor")
 
     @executor.setter
-    def executor(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def executor(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "executor", value)
 
     @_builtins.property
     @pulumi.getter(name="externalIps")
-    def external_ips(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def external_ips(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         Deployment external IPs
         """
         return pulumi.get(self, "external_ips")
 
     @external_ips.setter
-    def external_ips(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def external_ips(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "external_ips", value)
 
     @_builtins.property
     @pulumi.getter(name="imageRepository")
-    def image_repository(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def image_repository(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment image repository
         """
         return pulumi.get(self, "image_repository")
 
     @image_repository.setter
-    def image_repository(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def image_repository(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "image_repository", value)
 
     @_builtins.property
     @pulumi.getter(name="imageTag")
-    def image_tag(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def image_tag(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment image tag
         """
         return pulumi.get(self, "image_tag")
 
     @image_tag.setter
-    def image_tag(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def image_tag(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "image_tag", value)
 
     @_builtins.property
     @pulumi.getter(name="imageVersion")
-    def image_version(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def image_version(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment image version
         """
         return pulumi.get(self, "image_version")
 
     @image_version.setter
-    def image_version(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def image_version(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "image_version", value)
 
     @_builtins.property
     @pulumi.getter(name="isCicdEnforced")
-    def is_cicd_enforced(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_cicd_enforced(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Deployment CI/CD enforced
         """
         return pulumi.get(self, "is_cicd_enforced")
 
     @is_cicd_enforced.setter
-    def is_cicd_enforced(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_cicd_enforced(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_cicd_enforced", value)
 
     @_builtins.property
     @pulumi.getter(name="isDagDeployEnabled")
-    def is_dag_deploy_enabled(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_dag_deploy_enabled(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether DAG deploy is enabled - Changing this value may disrupt your deployment. Read more at https://docs.astronomer.io/astro/deploy-dags#enable-or-disable-dag-only-deploys-on-a-deployment
         """
         return pulumi.get(self, "is_dag_deploy_enabled")
 
     @is_dag_deploy_enabled.setter
-    def is_dag_deploy_enabled(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_dag_deploy_enabled(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_dag_deploy_enabled", value)
 
     @_builtins.property
     @pulumi.getter(name="isDevelopmentMode")
-    def is_development_mode(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_development_mode(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Deployment development mode - required for 'STANDARD' and 'DEDICATED' deployments. If changing from 'False' to 'True', the deployment will be recreated
         """
         return pulumi.get(self, "is_development_mode")
 
     @is_development_mode.setter
-    def is_development_mode(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_development_mode(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_development_mode", value)
 
     @_builtins.property
     @pulumi.getter(name="isHighAvailability")
-    def is_high_availability(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_high_availability(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Deployment high availability - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "is_high_availability")
 
     @is_high_availability.setter
-    def is_high_availability(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_high_availability(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_high_availability", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter
-    def namespace(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def namespace(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment namespace
         """
         return pulumi.get(self, "namespace")
 
     @namespace.setter
-    def namespace(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def namespace(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "namespace", value)
 
     @_builtins.property
     @pulumi.getter(name="oidcIssuerUrl")
-    def oidc_issuer_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def oidc_issuer_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment OIDC issuer URL
         """
         return pulumi.get(self, "oidc_issuer_url")
 
     @oidc_issuer_url.setter
-    def oidc_issuer_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def oidc_issuer_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "oidc_issuer_url", value)
 
     @_builtins.property
     @pulumi.getter(name="originalAstroRuntimeVersion")
-    def original_astro_runtime_version(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def original_astro_runtime_version(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment's original Astro Runtime version. The Terraform provider will use this provided Astro runtime version to create the Deployment. If not provided, defaults to the current Astro runtime version. The Astro runtime version can be updated with your Astro project Dockerfile, but if this value is changed, the Deployment will be recreated with this new Astro runtime version.
         """
         return pulumi.get(self, "original_astro_runtime_version")
 
     @original_astro_runtime_version.setter
-    def original_astro_runtime_version(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def original_astro_runtime_version(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "original_astro_runtime_version", value)
 
     @_builtins.property
     @pulumi.getter
-    def region(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def region(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment region - required for 'STANDARD' deployments. If changing this value, the deployment will be recreated in the new region
         """
         return pulumi.get(self, "region")
 
     @region.setter
-    def region(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def region(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "region", value)
 
     @_builtins.property
     @pulumi.getter(name="remoteExecution")
-    def remote_execution(self) -> Optional[pulumi.Input['DeploymentRemoteExecutionArgs']]:
+    def remote_execution(self) -> pulumi.Input[Optional['DeploymentRemoteExecutionArgs']]:
         """
         Deployment remote execution configuration - only for 'DEDICATED' deployments
         """
         return pulumi.get(self, "remote_execution")
 
     @remote_execution.setter
-    def remote_execution(self, value: Optional[pulumi.Input['DeploymentRemoteExecutionArgs']]):
+    def remote_execution(self, value: pulumi.Input[Optional['DeploymentRemoteExecutionArgs']]):
         pulumi.set(self, "remote_execution", value)
 
     @_builtins.property
     @pulumi.getter(name="resourceQuotaCpu")
-    def resource_quota_cpu(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def resource_quota_cpu(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment resource quota CPU - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "resource_quota_cpu")
 
     @resource_quota_cpu.setter
-    def resource_quota_cpu(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def resource_quota_cpu(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "resource_quota_cpu", value)
 
     @_builtins.property
     @pulumi.getter(name="resourceQuotaMemory")
-    def resource_quota_memory(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def resource_quota_memory(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment resource quota memory - required for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "resource_quota_memory")
 
     @resource_quota_memory.setter
-    def resource_quota_memory(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def resource_quota_memory(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "resource_quota_memory", value)
 
     @_builtins.property
     @pulumi.getter(name="scalingSpec")
-    def scaling_spec(self) -> Optional[pulumi.Input['DeploymentScalingSpecArgs']]:
+    def scaling_spec(self) -> pulumi.Input[Optional['DeploymentScalingSpecArgs']]:
         """
         Deployment scaling spec - only for 'STANDARD' and 'DEDICATED' deployments
         """
         return pulumi.get(self, "scaling_spec")
 
     @scaling_spec.setter
-    def scaling_spec(self, value: Optional[pulumi.Input['DeploymentScalingSpecArgs']]):
+    def scaling_spec(self, value: pulumi.Input[Optional['DeploymentScalingSpecArgs']]):
         pulumi.set(self, "scaling_spec", value)
 
     @_builtins.property
     @pulumi.getter(name="scalingStatus")
-    def scaling_status(self) -> Optional[pulumi.Input['DeploymentScalingStatusArgs']]:
+    def scaling_status(self) -> pulumi.Input[Optional['DeploymentScalingStatusArgs']]:
         """
         Deployment scaling status
         """
         return pulumi.get(self, "scaling_status")
 
     @scaling_status.setter
-    def scaling_status(self, value: Optional[pulumi.Input['DeploymentScalingStatusArgs']]):
+    def scaling_status(self, value: pulumi.Input[Optional['DeploymentScalingStatusArgs']]):
         pulumi.set(self, "scaling_status", value)
 
     @_builtins.property
     @pulumi.getter(name="schedulerAu")
-    def scheduler_au(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def scheduler_au(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         Deployment scheduler AU - required for 'HYBRID' deployments
         """
         return pulumi.get(self, "scheduler_au")
 
     @scheduler_au.setter
-    def scheduler_au(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def scheduler_au(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "scheduler_au", value)
 
     @_builtins.property
     @pulumi.getter(name="schedulerCpu")
-    def scheduler_cpu(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def scheduler_cpu(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment scheduler CPU
         """
         return pulumi.get(self, "scheduler_cpu")
 
     @scheduler_cpu.setter
-    def scheduler_cpu(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def scheduler_cpu(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "scheduler_cpu", value)
 
     @_builtins.property
     @pulumi.getter(name="schedulerMemory")
-    def scheduler_memory(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def scheduler_memory(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment scheduler memory
         """
         return pulumi.get(self, "scheduler_memory")
 
     @scheduler_memory.setter
-    def scheduler_memory(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def scheduler_memory(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "scheduler_memory", value)
 
     @_builtins.property
     @pulumi.getter(name="schedulerReplicas")
-    def scheduler_replicas(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def scheduler_replicas(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         Deployment scheduler replicas - required for 'HYBRID' deployments
         """
         return pulumi.get(self, "scheduler_replicas")
 
     @scheduler_replicas.setter
-    def scheduler_replicas(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def scheduler_replicas(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "scheduler_replicas", value)
 
     @_builtins.property
     @pulumi.getter(name="schedulerSize")
-    def scheduler_size(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def scheduler_size(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment scheduler size - required for 'STANDARD' and 'DEDICATED' deployments. Allowed values: `SMALL`, `MEDIUM`, `LARGE`, `EXTRALARGE`.
         """
         return pulumi.get(self, "scheduler_size")
 
     @scheduler_size.setter
-    def scheduler_size(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def scheduler_size(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "scheduler_size", value)
 
     @_builtins.property
     @pulumi.getter
-    def status(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def status(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment status
         """
         return pulumi.get(self, "status")
 
     @status.setter
-    def status(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def status(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "status", value)
 
     @_builtins.property
     @pulumi.getter(name="statusReason")
-    def status_reason(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def status_reason(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment status reason
         """
         return pulumi.get(self, "status_reason")
 
     @status_reason.setter
-    def status_reason(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def status_reason(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "status_reason", value)
 
     @_builtins.property
     @pulumi.getter(name="taskPodNodePoolId")
-    def task_pod_node_pool_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def task_pod_node_pool_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment task pod node pool identifier - required if executor is 'KUBERNETES' and type is 'HYBRID'
         """
         return pulumi.get(self, "task_pod_node_pool_id")
 
     @task_pod_node_pool_id.setter
-    def task_pod_node_pool_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def task_pod_node_pool_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "task_pod_node_pool_id", value)
 
     @_builtins.property
     @pulumi.getter
-    def type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment type - if changing this value, the deployment will be recreated with the new type
         """
         return pulumi.get(self, "type")
 
     @type.setter
-    def type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "type", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedBy")
-    def updated_by(self) -> Optional[pulumi.Input['DeploymentUpdatedByArgs']]:
+    def updated_by(self) -> pulumi.Input[Optional['DeploymentUpdatedByArgs']]:
         """
         Deployment updater
         """
         return pulumi.get(self, "updated_by")
 
     @updated_by.setter
-    def updated_by(self, value: Optional[pulumi.Input['DeploymentUpdatedByArgs']]):
+    def updated_by(self, value: pulumi.Input[Optional['DeploymentUpdatedByArgs']]):
         pulumi.set(self, "updated_by", value)
 
     @_builtins.property
     @pulumi.getter(name="webserverAirflowApiUrl")
-    def webserver_airflow_api_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def webserver_airflow_api_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment webserver Airflow API URL
         """
         return pulumi.get(self, "webserver_airflow_api_url")
 
     @webserver_airflow_api_url.setter
-    def webserver_airflow_api_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def webserver_airflow_api_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "webserver_airflow_api_url", value)
 
     @_builtins.property
     @pulumi.getter(name="webserverIngressHostname")
-    def webserver_ingress_hostname(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def webserver_ingress_hostname(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment webserver ingress hostname
         """
         return pulumi.get(self, "webserver_ingress_hostname")
 
     @webserver_ingress_hostname.setter
-    def webserver_ingress_hostname(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def webserver_ingress_hostname(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "webserver_ingress_hostname", value)
 
     @_builtins.property
     @pulumi.getter(name="webserverUrl")
-    def webserver_url(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def webserver_url(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment webserver URL
         """
         return pulumi.get(self, "webserver_url")
 
     @webserver_url.setter
-    def webserver_url(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def webserver_url(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "webserver_url", value)
 
     @_builtins.property
     @pulumi.getter(name="workerQueues")
-    def worker_queues(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]]:
+    def worker_queues(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]]:
         """
         Deployment worker queues - required for deployments with 'CELERY' executor. For 'STANDARD' and 'DEDICATED' deployments, use astro*machine. For 'HYBRID' deployments, use node*pool*id.
         """
         return pulumi.get(self, "worker_queues")
 
     @worker_queues.setter
-    def worker_queues(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]]):
+    def worker_queues(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['DeploymentWorkerQueueArgs']]]]):
         pulumi.set(self, "worker_queues", value)
 
     @_builtins.property
     @pulumi.getter(name="workloadIdentity")
-    def workload_identity(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def workload_identity(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment workload identity. This value can be changed via the Astro API if applicable.
         """
         return pulumi.get(self, "workload_identity")
 
     @workload_identity.setter
-    def workload_identity(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def workload_identity(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "workload_identity", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def workspace_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Deployment workspace identifier - if changing this value, the deployment will be recreated in the new workspace
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def workspace_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -1266,33 +1266,33 @@ class Deployment(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-                 cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 contact_emails: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 default_task_pod_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 default_task_pod_memory: Optional[pulumi.Input[_builtins.str]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 desired_workload_identity: Optional[pulumi.Input[_builtins.str]] = None,
-                 environment_variables: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentEnvironmentVariableArgs', 'DeploymentEnvironmentVariableArgsDict']]]]] = None,
-                 executor: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_cicd_enforced: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_dag_deploy_enabled: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_development_mode: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_high_availability: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 original_astro_runtime_version: Optional[pulumi.Input[_builtins.str]] = None,
-                 region: Optional[pulumi.Input[_builtins.str]] = None,
-                 remote_execution: Optional[pulumi.Input[Union['DeploymentRemoteExecutionArgs', 'DeploymentRemoteExecutionArgsDict']]] = None,
-                 resource_quota_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 resource_quota_memory: Optional[pulumi.Input[_builtins.str]] = None,
-                 scaling_spec: Optional[pulumi.Input[Union['DeploymentScalingSpecArgs', 'DeploymentScalingSpecArgsDict']]] = None,
-                 scheduler_au: Optional[pulumi.Input[_builtins.int]] = None,
-                 scheduler_replicas: Optional[pulumi.Input[_builtins.int]] = None,
-                 scheduler_size: Optional[pulumi.Input[_builtins.str]] = None,
-                 task_pod_node_pool_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
-                 worker_queues: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentWorkerQueueArgs', 'DeploymentWorkerQueueArgsDict']]]]] = None,
-                 workspace_id: Optional[pulumi.Input[_builtins.str]] = None,
+                 cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+                 cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 contact_emails: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 default_task_pod_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 default_task_pod_memory: pulumi.Input[Optional[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 desired_workload_identity: pulumi.Input[Optional[_builtins.str]] = None,
+                 environment_variables: pulumi.Input[Optional[Sequence[pulumi.Input[Union['DeploymentEnvironmentVariableArgs', 'DeploymentEnvironmentVariableArgsDict']]]]] = None,
+                 executor: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_cicd_enforced: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_dag_deploy_enabled: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_development_mode: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_high_availability: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 original_astro_runtime_version: pulumi.Input[Optional[_builtins.str]] = None,
+                 region: pulumi.Input[Optional[_builtins.str]] = None,
+                 remote_execution: pulumi.Input[Optional[Union['DeploymentRemoteExecutionArgs', 'DeploymentRemoteExecutionArgsDict']]] = None,
+                 resource_quota_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 resource_quota_memory: pulumi.Input[Optional[_builtins.str]] = None,
+                 scaling_spec: pulumi.Input[Optional[Union['DeploymentScalingSpecArgs', 'DeploymentScalingSpecArgsDict']]] = None,
+                 scheduler_au: pulumi.Input[Optional[_builtins.int]] = None,
+                 scheduler_replicas: pulumi.Input[Optional[_builtins.int]] = None,
+                 scheduler_size: pulumi.Input[Optional[_builtins.str]] = None,
+                 task_pod_node_pool_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
+                 worker_queues: pulumi.Input[Optional[Sequence[pulumi.Input[Union['DeploymentWorkerQueueArgs', 'DeploymentWorkerQueueArgsDict']]]]] = None,
+                 workspace_id: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         Deployment resource
@@ -1353,33 +1353,33 @@ class Deployment(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-                 cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 contact_emails: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 default_task_pod_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 default_task_pod_memory: Optional[pulumi.Input[_builtins.str]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 desired_workload_identity: Optional[pulumi.Input[_builtins.str]] = None,
-                 environment_variables: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentEnvironmentVariableArgs', 'DeploymentEnvironmentVariableArgsDict']]]]] = None,
-                 executor: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_cicd_enforced: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_dag_deploy_enabled: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_development_mode: Optional[pulumi.Input[_builtins.bool]] = None,
-                 is_high_availability: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 original_astro_runtime_version: Optional[pulumi.Input[_builtins.str]] = None,
-                 region: Optional[pulumi.Input[_builtins.str]] = None,
-                 remote_execution: Optional[pulumi.Input[Union['DeploymentRemoteExecutionArgs', 'DeploymentRemoteExecutionArgsDict']]] = None,
-                 resource_quota_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-                 resource_quota_memory: Optional[pulumi.Input[_builtins.str]] = None,
-                 scaling_spec: Optional[pulumi.Input[Union['DeploymentScalingSpecArgs', 'DeploymentScalingSpecArgsDict']]] = None,
-                 scheduler_au: Optional[pulumi.Input[_builtins.int]] = None,
-                 scheduler_replicas: Optional[pulumi.Input[_builtins.int]] = None,
-                 scheduler_size: Optional[pulumi.Input[_builtins.str]] = None,
-                 task_pod_node_pool_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
-                 worker_queues: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentWorkerQueueArgs', 'DeploymentWorkerQueueArgsDict']]]]] = None,
-                 workspace_id: Optional[pulumi.Input[_builtins.str]] = None,
+                 cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+                 cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 contact_emails: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 default_task_pod_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 default_task_pod_memory: pulumi.Input[Optional[_builtins.str]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 desired_workload_identity: pulumi.Input[Optional[_builtins.str]] = None,
+                 environment_variables: pulumi.Input[Optional[Sequence[pulumi.Input[Union['DeploymentEnvironmentVariableArgs', 'DeploymentEnvironmentVariableArgsDict']]]]] = None,
+                 executor: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_cicd_enforced: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_dag_deploy_enabled: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_development_mode: pulumi.Input[Optional[_builtins.bool]] = None,
+                 is_high_availability: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 original_astro_runtime_version: pulumi.Input[Optional[_builtins.str]] = None,
+                 region: pulumi.Input[Optional[_builtins.str]] = None,
+                 remote_execution: pulumi.Input[Optional[Union['DeploymentRemoteExecutionArgs', 'DeploymentRemoteExecutionArgsDict']]] = None,
+                 resource_quota_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+                 resource_quota_memory: pulumi.Input[Optional[_builtins.str]] = None,
+                 scaling_spec: pulumi.Input[Optional[Union['DeploymentScalingSpecArgs', 'DeploymentScalingSpecArgsDict']]] = None,
+                 scheduler_au: pulumi.Input[Optional[_builtins.int]] = None,
+                 scheduler_replicas: pulumi.Input[Optional[_builtins.int]] = None,
+                 scheduler_size: pulumi.Input[Optional[_builtins.str]] = None,
+                 task_pod_node_pool_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
+                 worker_queues: pulumi.Input[Optional[Sequence[pulumi.Input[Union['DeploymentWorkerQueueArgs', 'DeploymentWorkerQueueArgsDict']]]]] = None,
+                 workspace_id: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -1465,56 +1465,56 @@ class Deployment(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            airflow_version: Optional[pulumi.Input[_builtins.str]] = None,
-            astro_runtime_version: Optional[pulumi.Input[_builtins.str]] = None,
-            cloud_provider: Optional[pulumi.Input[_builtins.str]] = None,
-            cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-            contact_emails: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-            created_at: Optional[pulumi.Input[_builtins.str]] = None,
-            created_by: Optional[pulumi.Input[Union['DeploymentCreatedByArgs', 'DeploymentCreatedByArgsDict']]] = None,
-            dag_tarball_version: Optional[pulumi.Input[_builtins.str]] = None,
-            default_task_pod_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-            default_task_pod_memory: Optional[pulumi.Input[_builtins.str]] = None,
-            description: Optional[pulumi.Input[_builtins.str]] = None,
-            desired_dag_tarball_version: Optional[pulumi.Input[_builtins.str]] = None,
-            desired_workload_identity: Optional[pulumi.Input[_builtins.str]] = None,
-            environment_variables: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentEnvironmentVariableArgs', 'DeploymentEnvironmentVariableArgsDict']]]]] = None,
-            executor: Optional[pulumi.Input[_builtins.str]] = None,
-            external_ips: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-            image_repository: Optional[pulumi.Input[_builtins.str]] = None,
-            image_tag: Optional[pulumi.Input[_builtins.str]] = None,
-            image_version: Optional[pulumi.Input[_builtins.str]] = None,
-            is_cicd_enforced: Optional[pulumi.Input[_builtins.bool]] = None,
-            is_dag_deploy_enabled: Optional[pulumi.Input[_builtins.bool]] = None,
-            is_development_mode: Optional[pulumi.Input[_builtins.bool]] = None,
-            is_high_availability: Optional[pulumi.Input[_builtins.bool]] = None,
-            name: Optional[pulumi.Input[_builtins.str]] = None,
-            namespace: Optional[pulumi.Input[_builtins.str]] = None,
-            oidc_issuer_url: Optional[pulumi.Input[_builtins.str]] = None,
-            original_astro_runtime_version: Optional[pulumi.Input[_builtins.str]] = None,
-            region: Optional[pulumi.Input[_builtins.str]] = None,
-            remote_execution: Optional[pulumi.Input[Union['DeploymentRemoteExecutionArgs', 'DeploymentRemoteExecutionArgsDict']]] = None,
-            resource_quota_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-            resource_quota_memory: Optional[pulumi.Input[_builtins.str]] = None,
-            scaling_spec: Optional[pulumi.Input[Union['DeploymentScalingSpecArgs', 'DeploymentScalingSpecArgsDict']]] = None,
-            scaling_status: Optional[pulumi.Input[Union['DeploymentScalingStatusArgs', 'DeploymentScalingStatusArgsDict']]] = None,
-            scheduler_au: Optional[pulumi.Input[_builtins.int]] = None,
-            scheduler_cpu: Optional[pulumi.Input[_builtins.str]] = None,
-            scheduler_memory: Optional[pulumi.Input[_builtins.str]] = None,
-            scheduler_replicas: Optional[pulumi.Input[_builtins.int]] = None,
-            scheduler_size: Optional[pulumi.Input[_builtins.str]] = None,
-            status: Optional[pulumi.Input[_builtins.str]] = None,
-            status_reason: Optional[pulumi.Input[_builtins.str]] = None,
-            task_pod_node_pool_id: Optional[pulumi.Input[_builtins.str]] = None,
-            type: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_by: Optional[pulumi.Input[Union['DeploymentUpdatedByArgs', 'DeploymentUpdatedByArgsDict']]] = None,
-            webserver_airflow_api_url: Optional[pulumi.Input[_builtins.str]] = None,
-            webserver_ingress_hostname: Optional[pulumi.Input[_builtins.str]] = None,
-            webserver_url: Optional[pulumi.Input[_builtins.str]] = None,
-            worker_queues: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentWorkerQueueArgs', 'DeploymentWorkerQueueArgsDict']]]]] = None,
-            workload_identity: Optional[pulumi.Input[_builtins.str]] = None,
-            workspace_id: Optional[pulumi.Input[_builtins.str]] = None) -> 'Deployment':
+            airflow_version: pulumi.Input[Optional[_builtins.str]] = None,
+            astro_runtime_version: pulumi.Input[Optional[_builtins.str]] = None,
+            cloud_provider: pulumi.Input[Optional[_builtins.str]] = None,
+            cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+            contact_emails: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+            created_at: pulumi.Input[Optional[_builtins.str]] = None,
+            created_by: pulumi.Input[Optional[Union['DeploymentCreatedByArgs', 'DeploymentCreatedByArgsDict']]] = None,
+            dag_tarball_version: pulumi.Input[Optional[_builtins.str]] = None,
+            default_task_pod_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+            default_task_pod_memory: pulumi.Input[Optional[_builtins.str]] = None,
+            description: pulumi.Input[Optional[_builtins.str]] = None,
+            desired_dag_tarball_version: pulumi.Input[Optional[_builtins.str]] = None,
+            desired_workload_identity: pulumi.Input[Optional[_builtins.str]] = None,
+            environment_variables: pulumi.Input[Optional[Sequence[pulumi.Input[Union['DeploymentEnvironmentVariableArgs', 'DeploymentEnvironmentVariableArgsDict']]]]] = None,
+            executor: pulumi.Input[Optional[_builtins.str]] = None,
+            external_ips: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+            image_repository: pulumi.Input[Optional[_builtins.str]] = None,
+            image_tag: pulumi.Input[Optional[_builtins.str]] = None,
+            image_version: pulumi.Input[Optional[_builtins.str]] = None,
+            is_cicd_enforced: pulumi.Input[Optional[_builtins.bool]] = None,
+            is_dag_deploy_enabled: pulumi.Input[Optional[_builtins.bool]] = None,
+            is_development_mode: pulumi.Input[Optional[_builtins.bool]] = None,
+            is_high_availability: pulumi.Input[Optional[_builtins.bool]] = None,
+            name: pulumi.Input[Optional[_builtins.str]] = None,
+            namespace: pulumi.Input[Optional[_builtins.str]] = None,
+            oidc_issuer_url: pulumi.Input[Optional[_builtins.str]] = None,
+            original_astro_runtime_version: pulumi.Input[Optional[_builtins.str]] = None,
+            region: pulumi.Input[Optional[_builtins.str]] = None,
+            remote_execution: pulumi.Input[Optional[Union['DeploymentRemoteExecutionArgs', 'DeploymentRemoteExecutionArgsDict']]] = None,
+            resource_quota_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+            resource_quota_memory: pulumi.Input[Optional[_builtins.str]] = None,
+            scaling_spec: pulumi.Input[Optional[Union['DeploymentScalingSpecArgs', 'DeploymentScalingSpecArgsDict']]] = None,
+            scaling_status: pulumi.Input[Optional[Union['DeploymentScalingStatusArgs', 'DeploymentScalingStatusArgsDict']]] = None,
+            scheduler_au: pulumi.Input[Optional[_builtins.int]] = None,
+            scheduler_cpu: pulumi.Input[Optional[_builtins.str]] = None,
+            scheduler_memory: pulumi.Input[Optional[_builtins.str]] = None,
+            scheduler_replicas: pulumi.Input[Optional[_builtins.int]] = None,
+            scheduler_size: pulumi.Input[Optional[_builtins.str]] = None,
+            status: pulumi.Input[Optional[_builtins.str]] = None,
+            status_reason: pulumi.Input[Optional[_builtins.str]] = None,
+            task_pod_node_pool_id: pulumi.Input[Optional[_builtins.str]] = None,
+            type: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_by: pulumi.Input[Optional[Union['DeploymentUpdatedByArgs', 'DeploymentUpdatedByArgsDict']]] = None,
+            webserver_airflow_api_url: pulumi.Input[Optional[_builtins.str]] = None,
+            webserver_ingress_hostname: pulumi.Input[Optional[_builtins.str]] = None,
+            webserver_url: pulumi.Input[Optional[_builtins.str]] = None,
+            worker_queues: pulumi.Input[Optional[Sequence[pulumi.Input[Union['DeploymentWorkerQueueArgs', 'DeploymentWorkerQueueArgsDict']]]]] = None,
+            workload_identity: pulumi.Input[Optional[_builtins.str]] = None,
+            workspace_id: pulumi.Input[Optional[_builtins.str]] = None) -> 'Deployment':
         """
         Get an existing Deployment resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/get_alert.py
+++ b/sdk/python/pulumi_astronomer/get_alert.py
@@ -257,7 +257,7 @@ def get_alert(id: Optional[_builtins.str] = None,
         updated_at=pulumi.get(__ret__, 'updated_at'),
         updated_by=pulumi.get(__ret__, 'updated_by'),
         workspace_id=pulumi.get(__ret__, 'workspace_id'))
-def get_alert_output(id: Optional[pulumi.Input[_builtins.str]] = None,
+def get_alert_output(id: pulumi.Input[Optional[_builtins.str]] = None,
                      opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetAlertResult]:
     """
     Alert data source

--- a/sdk/python/pulumi_astronomer/get_alerts.py
+++ b/sdk/python/pulumi_astronomer/get_alerts.py
@@ -148,11 +148,11 @@ def get_alerts(alert_ids: Optional[Sequence[_builtins.str]] = None,
         entity_type=pulumi.get(__ret__, 'entity_type'),
         id=pulumi.get(__ret__, 'id'),
         workspace_ids=pulumi.get(__ret__, 'workspace_ids'))
-def get_alerts_output(alert_ids: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
-                      alert_types: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
-                      deployment_ids: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
-                      entity_type: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
-                      workspace_ids: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
+def get_alerts_output(alert_ids: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                      alert_types: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                      deployment_ids: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                      entity_type: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                      workspace_ids: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
                       opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetAlertsResult]:
     """
     Alerts data source

--- a/sdk/python/pulumi_astronomer/get_api_token.py
+++ b/sdk/python/pulumi_astronomer/get_api_token.py
@@ -244,7 +244,7 @@ def get_api_token(id: Optional[_builtins.str] = None,
         type=pulumi.get(__ret__, 'type'),
         updated_at=pulumi.get(__ret__, 'updated_at'),
         updated_by=pulumi.get(__ret__, 'updated_by'))
-def get_api_token_output(id: Optional[pulumi.Input[_builtins.str]] = None,
+def get_api_token_output(id: pulumi.Input[Optional[_builtins.str]] = None,
                          opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetApiTokenResult]:
     """
     API Token data source

--- a/sdk/python/pulumi_astronomer/get_api_tokens.py
+++ b/sdk/python/pulumi_astronomer/get_api_tokens.py
@@ -119,9 +119,9 @@ def get_api_tokens(deployment_id: Optional[_builtins.str] = None,
         id=pulumi.get(__ret__, 'id'),
         include_only_organization_tokens=pulumi.get(__ret__, 'include_only_organization_tokens'),
         workspace_id=pulumi.get(__ret__, 'workspace_id'))
-def get_api_tokens_output(deployment_id: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
-                          include_only_organization_tokens: Optional[pulumi.Input[Optional[_builtins.bool]]] = None,
-                          workspace_id: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
+def get_api_tokens_output(deployment_id: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                          include_only_organization_tokens: pulumi.Input[Optional[Optional[_builtins.bool]]] = None,
+                          workspace_id: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
                           opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetApiTokensResult]:
     """
     API Tokens data source

--- a/sdk/python/pulumi_astronomer/get_cluster.py
+++ b/sdk/python/pulumi_astronomer/get_cluster.py
@@ -413,7 +413,7 @@ def get_cluster(id: Optional[_builtins.str] = None,
         updated_at=pulumi.get(__ret__, 'updated_at'),
         vpc_subnet_range=pulumi.get(__ret__, 'vpc_subnet_range'),
         workspace_ids=pulumi.get(__ret__, 'workspace_ids'))
-def get_cluster_output(id: Optional[pulumi.Input[_builtins.str]] = None,
+def get_cluster_output(id: pulumi.Input[Optional[_builtins.str]] = None,
                        opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetClusterResult]:
     """
     Cluster data source

--- a/sdk/python/pulumi_astronomer/get_cluster_options.py
+++ b/sdk/python/pulumi_astronomer/get_cluster_options.py
@@ -112,8 +112,8 @@ def get_cluster_options(cloud_provider: Optional[_builtins.str] = None,
         cluster_options=pulumi.get(__ret__, 'cluster_options'),
         id=pulumi.get(__ret__, 'id'),
         type=pulumi.get(__ret__, 'type'))
-def get_cluster_options_output(cloud_provider: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
-                               type: Optional[pulumi.Input[_builtins.str]] = None,
+def get_cluster_options_output(cloud_provider: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                               type: pulumi.Input[Optional[_builtins.str]] = None,
                                opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetClusterOptionsResult]:
     """
     ClusterOptions data source

--- a/sdk/python/pulumi_astronomer/get_clusters.py
+++ b/sdk/python/pulumi_astronomer/get_clusters.py
@@ -112,8 +112,8 @@ def get_clusters(cloud_provider: Optional[_builtins.str] = None,
         clusters=pulumi.get(__ret__, 'clusters'),
         id=pulumi.get(__ret__, 'id'),
         names=pulumi.get(__ret__, 'names'))
-def get_clusters_output(cloud_provider: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
-                        names: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
+def get_clusters_output(cloud_provider: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                        names: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
                         opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetClustersResult]:
     """
     Clusters data source

--- a/sdk/python/pulumi_astronomer/get_custom_role.py
+++ b/sdk/python/pulumi_astronomer/get_custom_role.py
@@ -192,7 +192,7 @@ def get_custom_role(id: Optional[_builtins.str] = None,
         scope_type=pulumi.get(__ret__, 'scope_type'),
         updated_at=pulumi.get(__ret__, 'updated_at'),
         updated_by=pulumi.get(__ret__, 'updated_by'))
-def get_custom_role_output(id: Optional[pulumi.Input[_builtins.str]] = None,
+def get_custom_role_output(id: pulumi.Input[Optional[_builtins.str]] = None,
                            opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetCustomRoleResult]:
     """
     Custom role data source

--- a/sdk/python/pulumi_astronomer/get_deployment.py
+++ b/sdk/python/pulumi_astronomer/get_deployment.py
@@ -699,7 +699,7 @@ def get_deployment(id: Optional[_builtins.str] = None,
         worker_queues=pulumi.get(__ret__, 'worker_queues'),
         workload_identity=pulumi.get(__ret__, 'workload_identity'),
         workspace_id=pulumi.get(__ret__, 'workspace_id'))
-def get_deployment_output(id: Optional[pulumi.Input[_builtins.str]] = None,
+def get_deployment_output(id: pulumi.Input[Optional[_builtins.str]] = None,
                           opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetDeploymentResult]:
     """
     Deployment data source

--- a/sdk/python/pulumi_astronomer/get_deployment_options.py
+++ b/sdk/python/pulumi_astronomer/get_deployment_options.py
@@ -231,10 +231,10 @@ def get_deployment_options(cloud_provider: Optional[_builtins.str] = None,
         worker_machines=pulumi.get(__ret__, 'worker_machines'),
         worker_queues=pulumi.get(__ret__, 'worker_queues'),
         workload_identity_options=pulumi.get(__ret__, 'workload_identity_options'))
-def get_deployment_options_output(cloud_provider: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
-                                  deployment_id: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
-                                  deployment_type: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
-                                  executor: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
+def get_deployment_options_output(cloud_provider: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                                  deployment_id: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                                  deployment_type: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                                  executor: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
                                   opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetDeploymentOptionsResult]:
     """
     Deployment options data source

--- a/sdk/python/pulumi_astronomer/get_deployments.py
+++ b/sdk/python/pulumi_astronomer/get_deployments.py
@@ -119,9 +119,9 @@ def get_deployments(deployment_ids: Optional[Sequence[_builtins.str]] = None,
         id=pulumi.get(__ret__, 'id'),
         names=pulumi.get(__ret__, 'names'),
         workspace_ids=pulumi.get(__ret__, 'workspace_ids'))
-def get_deployments_output(deployment_ids: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
-                           names: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
-                           workspace_ids: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
+def get_deployments_output(deployment_ids: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                           names: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                           workspace_ids: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
                            opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetDeploymentsResult]:
     """
     Deployments data source

--- a/sdk/python/pulumi_astronomer/get_notification_channel.py
+++ b/sdk/python/pulumi_astronomer/get_notification_channel.py
@@ -244,7 +244,7 @@ def get_notification_channel(id: Optional[_builtins.str] = None,
         updated_at=pulumi.get(__ret__, 'updated_at'),
         updated_by=pulumi.get(__ret__, 'updated_by'),
         workspace_id=pulumi.get(__ret__, 'workspace_id'))
-def get_notification_channel_output(id: Optional[pulumi.Input[_builtins.str]] = None,
+def get_notification_channel_output(id: pulumi.Input[Optional[_builtins.str]] = None,
                                     opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetNotificationChannelResult]:
     """
     Notification Channel data source

--- a/sdk/python/pulumi_astronomer/get_notification_channels.py
+++ b/sdk/python/pulumi_astronomer/get_notification_channels.py
@@ -132,11 +132,11 @@ def get_notification_channels(channel_types: Optional[Sequence[_builtins.str]] =
         notification_channel_ids=pulumi.get(__ret__, 'notification_channel_ids'),
         notification_channels=pulumi.get(__ret__, 'notification_channels'),
         workspace_ids=pulumi.get(__ret__, 'workspace_ids'))
-def get_notification_channels_output(channel_types: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
-                                     deployment_ids: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
-                                     entity_type: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
-                                     notification_channel_ids: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
-                                     workspace_ids: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
+def get_notification_channels_output(channel_types: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                                     deployment_ids: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                                     entity_type: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                                     notification_channel_ids: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                                     workspace_ids: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
                                      opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetNotificationChannelsResult]:
     """
     Notification Channels data source

--- a/sdk/python/pulumi_astronomer/get_team.py
+++ b/sdk/python/pulumi_astronomer/get_team.py
@@ -244,7 +244,7 @@ def get_team(id: Optional[_builtins.str] = None,
         updated_at=pulumi.get(__ret__, 'updated_at'),
         updated_by=pulumi.get(__ret__, 'updated_by'),
         workspace_roles=pulumi.get(__ret__, 'workspace_roles'))
-def get_team_output(id: Optional[pulumi.Input[_builtins.str]] = None,
+def get_team_output(id: pulumi.Input[Optional[_builtins.str]] = None,
                     opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetTeamResult]:
     """
     Team data source

--- a/sdk/python/pulumi_astronomer/get_teams.py
+++ b/sdk/python/pulumi_astronomer/get_teams.py
@@ -96,7 +96,7 @@ def get_teams(names: Optional[Sequence[_builtins.str]] = None,
         id=pulumi.get(__ret__, 'id'),
         names=pulumi.get(__ret__, 'names'),
         teams=pulumi.get(__ret__, 'teams'))
-def get_teams_output(names: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
+def get_teams_output(names: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
                      opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetTeamsResult]:
     """
     Teams data source

--- a/sdk/python/pulumi_astronomer/get_user.py
+++ b/sdk/python/pulumi_astronomer/get_user.py
@@ -205,7 +205,7 @@ def get_user(id: Optional[_builtins.str] = None,
         updated_at=pulumi.get(__ret__, 'updated_at'),
         username=pulumi.get(__ret__, 'username'),
         workspace_roles=pulumi.get(__ret__, 'workspace_roles'))
-def get_user_output(id: Optional[pulumi.Input[_builtins.str]] = None,
+def get_user_output(id: pulumi.Input[Optional[_builtins.str]] = None,
                     opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetUserResult]:
     """
     User data source

--- a/sdk/python/pulumi_astronomer/get_users.py
+++ b/sdk/python/pulumi_astronomer/get_users.py
@@ -106,8 +106,8 @@ def get_users(deployment_id: Optional[_builtins.str] = None,
         id=pulumi.get(__ret__, 'id'),
         users=pulumi.get(__ret__, 'users'),
         workspace_id=pulumi.get(__ret__, 'workspace_id'))
-def get_users_output(deployment_id: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
-                     workspace_id: Optional[pulumi.Input[Optional[_builtins.str]]] = None,
+def get_users_output(deployment_id: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
+                     workspace_id: pulumi.Input[Optional[Optional[_builtins.str]]] = None,
                      opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetUsersResult]:
     """
     Users data source

--- a/sdk/python/pulumi_astronomer/get_workspace.py
+++ b/sdk/python/pulumi_astronomer/get_workspace.py
@@ -166,7 +166,7 @@ def get_workspace(id: Optional[_builtins.str] = None,
         name=pulumi.get(__ret__, 'name'),
         updated_at=pulumi.get(__ret__, 'updated_at'),
         updated_by=pulumi.get(__ret__, 'updated_by'))
-def get_workspace_output(id: Optional[pulumi.Input[_builtins.str]] = None,
+def get_workspace_output(id: pulumi.Input[Optional[_builtins.str]] = None,
                          opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetWorkspaceResult]:
     """
     Workspace data source

--- a/sdk/python/pulumi_astronomer/get_workspaces.py
+++ b/sdk/python/pulumi_astronomer/get_workspaces.py
@@ -112,8 +112,8 @@ def get_workspaces(names: Optional[Sequence[_builtins.str]] = None,
         names=pulumi.get(__ret__, 'names'),
         workspace_ids=pulumi.get(__ret__, 'workspace_ids'),
         workspaces=pulumi.get(__ret__, 'workspaces'))
-def get_workspaces_output(names: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
-                          workspace_ids: Optional[pulumi.Input[Optional[Sequence[_builtins.str]]]] = None,
+def get_workspaces_output(names: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
+                          workspace_ids: pulumi.Input[Optional[Optional[Sequence[_builtins.str]]]] = None,
                           opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetWorkspacesResult]:
     """
     Workspaces data source

--- a/sdk/python/pulumi_astronomer/hybrid_cluster_workspace_authorization.py
+++ b/sdk/python/pulumi_astronomer/hybrid_cluster_workspace_authorization.py
@@ -20,7 +20,7 @@ __all__ = ['HybridClusterWorkspaceAuthorizationArgs', 'HybridClusterWorkspaceAut
 class HybridClusterWorkspaceAuthorizationArgs:
     def __init__(__self__, *,
                  cluster_id: pulumi.Input[_builtins.str],
-                 workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None):
+                 workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None):
         """
         The set of arguments for constructing a HybridClusterWorkspaceAuthorization resource.
 
@@ -45,22 +45,22 @@ class HybridClusterWorkspaceAuthorizationArgs:
 
     @_builtins.property
     @pulumi.getter(name="workspaceIds")
-    def workspace_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def workspace_ids(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The IDs of the workspaces to authorize for the hybrid cluster
         """
         return pulumi.get(self, "workspace_ids")
 
     @workspace_ids.setter
-    def workspace_ids(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def workspace_ids(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "workspace_ids", value)
 
 
 @pulumi.input_type
 class _HybridClusterWorkspaceAuthorizationState:
     def __init__(__self__, *,
-                 cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None):
+                 cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None):
         """
         Input properties used for looking up and filtering HybridClusterWorkspaceAuthorization resources.
 
@@ -74,26 +74,26 @@ class _HybridClusterWorkspaceAuthorizationState:
 
     @_builtins.property
     @pulumi.getter(name="clusterId")
-    def cluster_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def cluster_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the hybrid cluster to set authorizations for
         """
         return pulumi.get(self, "cluster_id")
 
     @cluster_id.setter
-    def cluster_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def cluster_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "cluster_id", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceIds")
-    def workspace_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def workspace_ids(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The IDs of the workspaces to authorize for the hybrid cluster
         """
         return pulumi.get(self, "workspace_ids")
 
     @workspace_ids.setter
-    def workspace_ids(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def workspace_ids(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "workspace_ids", value)
 
 
@@ -103,8 +103,8 @@ class HybridClusterWorkspaceAuthorization(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  __props__=None):
         """
         Hybrid cluster workspace authorization resource
@@ -140,8 +140,8 @@ class HybridClusterWorkspaceAuthorization(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -165,8 +165,8 @@ class HybridClusterWorkspaceAuthorization(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            cluster_id: Optional[pulumi.Input[_builtins.str]] = None,
-            workspace_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None) -> 'HybridClusterWorkspaceAuthorization':
+            cluster_id: pulumi.Input[Optional[_builtins.str]] = None,
+            workspace_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None) -> 'HybridClusterWorkspaceAuthorization':
         """
         Get an existing HybridClusterWorkspaceAuthorization resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/notification_channel.py
+++ b/sdk/python/pulumi_astronomer/notification_channel.py
@@ -25,8 +25,8 @@ class NotificationChannelArgs:
                  entity_id: pulumi.Input[_builtins.str],
                  entity_type: pulumi.Input[_builtins.str],
                  type: pulumi.Input[_builtins.str],
-                 is_shared: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None):
+                 is_shared: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None):
         """
         The set of arguments for constructing a NotificationChannel resource.
 
@@ -96,45 +96,45 @@ class NotificationChannelArgs:
 
     @_builtins.property
     @pulumi.getter(name="isShared")
-    def is_shared(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_shared(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         When entity type is scoped to ORGANIZATION or WORKSPACE, this determines if child entities can access this notification channel.
         """
         return pulumi.get(self, "is_shared")
 
     @is_shared.setter
-    def is_shared(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_shared(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_shared", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The notification channel's name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
 class _NotificationChannelState:
     def __init__(__self__, *,
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_by: Optional[pulumi.Input['NotificationChannelCreatedByArgs']] = None,
-                 definition: Optional[pulumi.Input['NotificationChannelDefinitionArgs']] = None,
-                 deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_shared: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_by: Optional[pulumi.Input['NotificationChannelUpdatedByArgs']] = None,
-                 workspace_id: Optional[pulumi.Input[_builtins.str]] = None):
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_by: pulumi.Input[Optional['NotificationChannelCreatedByArgs']] = None,
+                 definition: pulumi.Input[Optional['NotificationChannelDefinitionArgs']] = None,
+                 deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_name: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_shared: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_by: pulumi.Input[Optional['NotificationChannelUpdatedByArgs']] = None,
+                 workspace_id: pulumi.Input[Optional[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering NotificationChannel resources.
 
@@ -181,158 +181,158 @@ class _NotificationChannelState:
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Notification Channel creation timestamp
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter(name="createdBy")
-    def created_by(self) -> Optional[pulumi.Input['NotificationChannelCreatedByArgs']]:
+    def created_by(self) -> pulumi.Input[Optional['NotificationChannelCreatedByArgs']]:
         """
         Notification Channel creator
         """
         return pulumi.get(self, "created_by")
 
     @created_by.setter
-    def created_by(self, value: Optional[pulumi.Input['NotificationChannelCreatedByArgs']]):
+    def created_by(self, value: pulumi.Input[Optional['NotificationChannelCreatedByArgs']]):
         pulumi.set(self, "created_by", value)
 
     @_builtins.property
     @pulumi.getter
-    def definition(self) -> Optional[pulumi.Input['NotificationChannelDefinitionArgs']]:
+    def definition(self) -> pulumi.Input[Optional['NotificationChannelDefinitionArgs']]:
         """
         The notification channel's definition
         """
         return pulumi.get(self, "definition")
 
     @definition.setter
-    def definition(self, value: Optional[pulumi.Input['NotificationChannelDefinitionArgs']]):
+    def definition(self, value: pulumi.Input[Optional['NotificationChannelDefinitionArgs']]):
         pulumi.set(self, "definition", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentId")
-    def deployment_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def deployment_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The deployment ID the notification channel is scoped to
         """
         return pulumi.get(self, "deployment_id")
 
     @deployment_id.setter
-    def deployment_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def deployment_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "deployment_id", value)
 
     @_builtins.property
     @pulumi.getter(name="entityId")
-    def entity_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def entity_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The entity ID the notification channel is scoped to
         """
         return pulumi.get(self, "entity_id")
 
     @entity_id.setter
-    def entity_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def entity_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "entity_id", value)
 
     @_builtins.property
     @pulumi.getter(name="entityName")
-    def entity_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def entity_name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The name of the entity the notification channel is scoped to
         """
         return pulumi.get(self, "entity_name")
 
     @entity_name.setter
-    def entity_name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def entity_name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "entity_name", value)
 
     @_builtins.property
     @pulumi.getter(name="entityType")
-    def entity_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def entity_type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The type of entity the notification channel is scoped to (e.g., 'DEPLOYMENT')
         """
         return pulumi.get(self, "entity_type")
 
     @entity_type.setter
-    def entity_type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def entity_type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "entity_type", value)
 
     @_builtins.property
     @pulumi.getter(name="isShared")
-    def is_shared(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_shared(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         When entity type is scoped to ORGANIZATION or WORKSPACE, this determines if child entities can access this notification channel.
         """
         return pulumi.get(self, "is_shared")
 
     @is_shared.setter
-    def is_shared(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_shared(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_shared", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The notification channel's name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter
-    def type(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def type(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The notification channel's type
         """
         return pulumi.get(self, "type")
 
     @type.setter
-    def type(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def type(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "type", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Notification Channel last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedBy")
-    def updated_by(self) -> Optional[pulumi.Input['NotificationChannelUpdatedByArgs']]:
+    def updated_by(self) -> pulumi.Input[Optional['NotificationChannelUpdatedByArgs']]:
         """
         Notification Channel updater
         """
         return pulumi.get(self, "updated_by")
 
     @updated_by.setter
-    def updated_by(self, value: Optional[pulumi.Input['NotificationChannelUpdatedByArgs']]):
+    def updated_by(self, value: pulumi.Input[Optional['NotificationChannelUpdatedByArgs']]):
         pulumi.set(self, "updated_by", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def workspace_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The workspace ID the notification channel is scoped to
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def workspace_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -342,12 +342,12 @@ class NotificationChannel(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 definition: Optional[pulumi.Input[Union['NotificationChannelDefinitionArgs', 'NotificationChannelDefinitionArgsDict']]] = None,
-                 entity_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_shared: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
+                 definition: pulumi.Input[Optional[Union['NotificationChannelDefinitionArgs', 'NotificationChannelDefinitionArgsDict']]] = None,
+                 entity_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_shared: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         Notification Channel resource
@@ -387,12 +387,12 @@ class NotificationChannel(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 definition: Optional[pulumi.Input[Union['NotificationChannelDefinitionArgs', 'NotificationChannelDefinitionArgsDict']]] = None,
-                 entity_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 entity_type: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_shared: Optional[pulumi.Input[_builtins.bool]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 type: Optional[pulumi.Input[_builtins.str]] = None,
+                 definition: pulumi.Input[Optional[Union['NotificationChannelDefinitionArgs', 'NotificationChannelDefinitionArgsDict']]] = None,
+                 entity_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 entity_type: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_shared: pulumi.Input[Optional[_builtins.bool]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 type: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -433,19 +433,19 @@ class NotificationChannel(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            created_at: Optional[pulumi.Input[_builtins.str]] = None,
-            created_by: Optional[pulumi.Input[Union['NotificationChannelCreatedByArgs', 'NotificationChannelCreatedByArgsDict']]] = None,
-            definition: Optional[pulumi.Input[Union['NotificationChannelDefinitionArgs', 'NotificationChannelDefinitionArgsDict']]] = None,
-            deployment_id: Optional[pulumi.Input[_builtins.str]] = None,
-            entity_id: Optional[pulumi.Input[_builtins.str]] = None,
-            entity_name: Optional[pulumi.Input[_builtins.str]] = None,
-            entity_type: Optional[pulumi.Input[_builtins.str]] = None,
-            is_shared: Optional[pulumi.Input[_builtins.bool]] = None,
-            name: Optional[pulumi.Input[_builtins.str]] = None,
-            type: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_by: Optional[pulumi.Input[Union['NotificationChannelUpdatedByArgs', 'NotificationChannelUpdatedByArgsDict']]] = None,
-            workspace_id: Optional[pulumi.Input[_builtins.str]] = None) -> 'NotificationChannel':
+            created_at: pulumi.Input[Optional[_builtins.str]] = None,
+            created_by: pulumi.Input[Optional[Union['NotificationChannelCreatedByArgs', 'NotificationChannelCreatedByArgsDict']]] = None,
+            definition: pulumi.Input[Optional[Union['NotificationChannelDefinitionArgs', 'NotificationChannelDefinitionArgsDict']]] = None,
+            deployment_id: pulumi.Input[Optional[_builtins.str]] = None,
+            entity_id: pulumi.Input[Optional[_builtins.str]] = None,
+            entity_name: pulumi.Input[Optional[_builtins.str]] = None,
+            entity_type: pulumi.Input[Optional[_builtins.str]] = None,
+            is_shared: pulumi.Input[Optional[_builtins.bool]] = None,
+            name: pulumi.Input[Optional[_builtins.str]] = None,
+            type: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_by: pulumi.Input[Optional[Union['NotificationChannelUpdatedByArgs', 'NotificationChannelUpdatedByArgsDict']]] = None,
+            workspace_id: pulumi.Input[Optional[_builtins.str]] = None) -> 'NotificationChannel':
         """
         Get an existing NotificationChannel resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/provider.py
+++ b/sdk/python/pulumi_astronomer/provider.py
@@ -19,9 +19,9 @@ __all__ = ['ProviderArgs', 'Provider']
 @pulumi.input_type
 class ProviderArgs:
     def __init__(__self__, *,
-                 host: Optional[pulumi.Input[_builtins.str]] = None,
-                 organization_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 token: Optional[pulumi.Input[_builtins.str]] = None):
+                 host: pulumi.Input[Optional[_builtins.str]] = None,
+                 organization_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 token: pulumi.Input[Optional[_builtins.str]] = None):
         """
         The set of arguments for constructing a Provider resource.
 
@@ -42,38 +42,38 @@ class ProviderArgs:
 
     @_builtins.property
     @pulumi.getter
-    def host(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def host(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         API host to use for the provider. Default is `https://api.astronomer.io`
         """
         return pulumi.get(self, "host")
 
     @host.setter
-    def host(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def host(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "host", value)
 
     @_builtins.property
     @pulumi.getter(name="organizationId")
-    def organization_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def organization_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Organization ID this provider will operate on.
         """
         return pulumi.get(self, "organization_id")
 
     @organization_id.setter
-    def organization_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def organization_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "organization_id", value)
 
     @_builtins.property
     @pulumi.getter
-    def token(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def token(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Astro API Token. Can be set with an `ASTRO_API_TOKEN` env var.
         """
         return pulumi.get(self, "token")
 
     @token.setter
-    def token(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def token(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "token", value)
 
 
@@ -83,9 +83,9 @@ class Provider(pulumi.ProviderResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 host: Optional[pulumi.Input[_builtins.str]] = None,
-                 organization_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 token: Optional[pulumi.Input[_builtins.str]] = None,
+                 host: pulumi.Input[Optional[_builtins.str]] = None,
+                 organization_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 token: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         The provider type for the astro package. By default, resources use package-wide configuration
@@ -128,9 +128,9 @@ class Provider(pulumi.ProviderResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 host: Optional[pulumi.Input[_builtins.str]] = None,
-                 organization_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 token: Optional[pulumi.Input[_builtins.str]] = None,
+                 host: pulumi.Input[Optional[_builtins.str]] = None,
+                 organization_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 token: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_astronomer/team.py
+++ b/sdk/python/pulumi_astronomer/team.py
@@ -22,12 +22,12 @@ __all__ = ['TeamArgs', 'Team']
 class TeamArgs:
     def __init__(__self__, *,
                  organization_role: pulumi.Input[_builtins.str],
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamDagRoleArgs']]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 member_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]] = None):
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamDagRoleArgs']]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 member_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]] = None):
         """
         The set of arguments for constructing a Team resource.
 
@@ -67,93 +67,93 @@ class TeamArgs:
 
     @_builtins.property
     @pulumi.getter(name="dagRoles")
-    def dag_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamDagRoleArgs']]]]:
+    def dag_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamDagRoleArgs']]]]:
         """
         The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (for example `DEPLOYMENT_ACCESSOR`).
         """
         return pulumi.get(self, "dag_roles")
 
     @dag_roles.setter
-    def dag_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamDagRoleArgs']]]]):
+    def dag_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamDagRoleArgs']]]]):
         pulumi.set(self, "dag_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentRoles")
-    def deployment_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]]:
+    def deployment_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]]:
         """
         The roles to assign to the Deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.
         """
         return pulumi.get(self, "deployment_roles")
 
     @deployment_roles.setter
-    def deployment_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]]):
+    def deployment_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]]):
         pulumi.set(self, "deployment_roles", value)
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Team description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter(name="memberIds")
-    def member_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def member_ids(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The IDs of the users to add to the Team
         """
         return pulumi.get(self, "member_ids")
 
     @member_ids.setter
-    def member_ids(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def member_ids(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "member_ids", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Team name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceRoles")
-    def workspace_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]]:
+    def workspace_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]]:
         """
         The roles to assign to the Workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
         """
         return pulumi.get(self, "workspace_roles")
 
     @workspace_roles.setter
-    def workspace_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]]):
+    def workspace_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]]):
         pulumi.set(self, "workspace_roles", value)
 
 
 @pulumi.input_type
 class _TeamState:
     def __init__(__self__, *,
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_by: Optional[pulumi.Input['TeamCreatedByArgs']] = None,
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamDagRoleArgs']]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 is_idp_managed: Optional[pulumi.Input[_builtins.bool]] = None,
-                 member_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-                 roles_count: Optional[pulumi.Input[_builtins.int]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_by: Optional[pulumi.Input['TeamUpdatedByArgs']] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]] = None):
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_by: pulumi.Input[Optional['TeamCreatedByArgs']] = None,
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamDagRoleArgs']]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 is_idp_managed: pulumi.Input[Optional[_builtins.bool]] = None,
+                 member_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+                 roles_count: pulumi.Input[Optional[_builtins.int]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_by: pulumi.Input[Optional['TeamUpdatedByArgs']] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]] = None):
         """
         Input properties used for looking up and filtering Team resources.
 
@@ -200,158 +200,158 @@ class _TeamState:
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Team creation timestamp
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter(name="createdBy")
-    def created_by(self) -> Optional[pulumi.Input['TeamCreatedByArgs']]:
+    def created_by(self) -> pulumi.Input[Optional['TeamCreatedByArgs']]:
         """
         Team creator
         """
         return pulumi.get(self, "created_by")
 
     @created_by.setter
-    def created_by(self, value: Optional[pulumi.Input['TeamCreatedByArgs']]):
+    def created_by(self, value: pulumi.Input[Optional['TeamCreatedByArgs']]):
         pulumi.set(self, "created_by", value)
 
     @_builtins.property
     @pulumi.getter(name="dagRoles")
-    def dag_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamDagRoleArgs']]]]:
+    def dag_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamDagRoleArgs']]]]:
         """
         The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (for example `DEPLOYMENT_ACCESSOR`).
         """
         return pulumi.get(self, "dag_roles")
 
     @dag_roles.setter
-    def dag_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamDagRoleArgs']]]]):
+    def dag_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamDagRoleArgs']]]]):
         pulumi.set(self, "dag_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentRoles")
-    def deployment_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]]:
+    def deployment_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]]:
         """
         The roles to assign to the Deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.
         """
         return pulumi.get(self, "deployment_roles")
 
     @deployment_roles.setter
-    def deployment_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]]):
+    def deployment_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamDeploymentRoleArgs']]]]):
         pulumi.set(self, "deployment_roles", value)
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Team description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter(name="isIdpManaged")
-    def is_idp_managed(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def is_idp_managed(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether the Team is managed by an identity provider
         """
         return pulumi.get(self, "is_idp_managed")
 
     @is_idp_managed.setter
-    def is_idp_managed(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def is_idp_managed(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "is_idp_managed", value)
 
     @_builtins.property
     @pulumi.getter(name="memberIds")
-    def member_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+    def member_ids(self) -> pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]:
         """
         The IDs of the users to add to the Team
         """
         return pulumi.get(self, "member_ids")
 
     @member_ids.setter
-    def member_ids(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]):
+    def member_ids(self, value: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]]):
         pulumi.set(self, "member_ids", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Team name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter(name="organizationRole")
-    def organization_role(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def organization_role(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The role to assign to the Organization
         """
         return pulumi.get(self, "organization_role")
 
     @organization_role.setter
-    def organization_role(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def organization_role(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "organization_role", value)
 
     @_builtins.property
     @pulumi.getter(name="rolesCount")
-    def roles_count(self) -> Optional[pulumi.Input[_builtins.int]]:
+    def roles_count(self) -> pulumi.Input[Optional[_builtins.int]]:
         """
         Number of roles assigned to the Team
         """
         return pulumi.get(self, "roles_count")
 
     @roles_count.setter
-    def roles_count(self, value: Optional[pulumi.Input[_builtins.int]]):
+    def roles_count(self, value: pulumi.Input[Optional[_builtins.int]]):
         pulumi.set(self, "roles_count", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Team last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedBy")
-    def updated_by(self) -> Optional[pulumi.Input['TeamUpdatedByArgs']]:
+    def updated_by(self) -> pulumi.Input[Optional['TeamUpdatedByArgs']]:
         """
         Team updater
         """
         return pulumi.get(self, "updated_by")
 
     @updated_by.setter
-    def updated_by(self, value: Optional[pulumi.Input['TeamUpdatedByArgs']]):
+    def updated_by(self, value: pulumi.Input[Optional['TeamUpdatedByArgs']]):
         pulumi.set(self, "updated_by", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceRoles")
-    def workspace_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]]:
+    def workspace_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]]:
         """
         The roles to assign to the Workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
         """
         return pulumi.get(self, "workspace_roles")
 
     @workspace_roles.setter
-    def workspace_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]]):
+    def workspace_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamWorkspaceRoleArgs']]]]):
         pulumi.set(self, "workspace_roles", value)
 
 
@@ -361,13 +361,13 @@ class Team(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamDagRoleArgs', 'TeamDagRoleArgsDict']]]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamDeploymentRoleArgs', 'TeamDeploymentRoleArgsDict']]]]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 member_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamWorkspaceRoleArgs', 'TeamWorkspaceRoleArgsDict']]]]] = None,
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamDagRoleArgs', 'TeamDagRoleArgsDict']]]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamDeploymentRoleArgs', 'TeamDeploymentRoleArgsDict']]]]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 member_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamWorkspaceRoleArgs', 'TeamWorkspaceRoleArgsDict']]]]] = None,
                  __props__=None):
         """
         Creates and manages a team and its members. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.
@@ -408,13 +408,13 @@ class Team(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamDagRoleArgs', 'TeamDagRoleArgsDict']]]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamDeploymentRoleArgs', 'TeamDeploymentRoleArgsDict']]]]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 member_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamWorkspaceRoleArgs', 'TeamWorkspaceRoleArgsDict']]]]] = None,
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamDagRoleArgs', 'TeamDagRoleArgsDict']]]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamDeploymentRoleArgs', 'TeamDeploymentRoleArgsDict']]]]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 member_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamWorkspaceRoleArgs', 'TeamWorkspaceRoleArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -449,19 +449,19 @@ class Team(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            created_at: Optional[pulumi.Input[_builtins.str]] = None,
-            created_by: Optional[pulumi.Input[Union['TeamCreatedByArgs', 'TeamCreatedByArgsDict']]] = None,
-            dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamDagRoleArgs', 'TeamDagRoleArgsDict']]]]] = None,
-            deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamDeploymentRoleArgs', 'TeamDeploymentRoleArgsDict']]]]] = None,
-            description: Optional[pulumi.Input[_builtins.str]] = None,
-            is_idp_managed: Optional[pulumi.Input[_builtins.bool]] = None,
-            member_ids: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
-            name: Optional[pulumi.Input[_builtins.str]] = None,
-            organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-            roles_count: Optional[pulumi.Input[_builtins.int]] = None,
-            updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_by: Optional[pulumi.Input[Union['TeamUpdatedByArgs', 'TeamUpdatedByArgsDict']]] = None,
-            workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamWorkspaceRoleArgs', 'TeamWorkspaceRoleArgsDict']]]]] = None) -> 'Team':
+            created_at: pulumi.Input[Optional[_builtins.str]] = None,
+            created_by: pulumi.Input[Optional[Union['TeamCreatedByArgs', 'TeamCreatedByArgsDict']]] = None,
+            dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamDagRoleArgs', 'TeamDagRoleArgsDict']]]]] = None,
+            deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamDeploymentRoleArgs', 'TeamDeploymentRoleArgsDict']]]]] = None,
+            description: pulumi.Input[Optional[_builtins.str]] = None,
+            is_idp_managed: pulumi.Input[Optional[_builtins.bool]] = None,
+            member_ids: pulumi.Input[Optional[Sequence[pulumi.Input[_builtins.str]]]] = None,
+            name: pulumi.Input[Optional[_builtins.str]] = None,
+            organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+            roles_count: pulumi.Input[Optional[_builtins.int]] = None,
+            updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_by: pulumi.Input[Optional[Union['TeamUpdatedByArgs', 'TeamUpdatedByArgsDict']]] = None,
+            workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamWorkspaceRoleArgs', 'TeamWorkspaceRoleArgsDict']]]]] = None) -> 'Team':
         """
         Get an existing Team resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/team_membership.py
+++ b/sdk/python/pulumi_astronomer/team_membership.py
@@ -58,8 +58,8 @@ class TeamMembershipArgs:
 @pulumi.input_type
 class _TeamMembershipState:
     def __init__(__self__, *,
-                 team_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 user_id: Optional[pulumi.Input[_builtins.str]] = None):
+                 team_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 user_id: pulumi.Input[Optional[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering TeamMembership resources.
 
@@ -73,26 +73,26 @@ class _TeamMembershipState:
 
     @_builtins.property
     @pulumi.getter(name="teamId")
-    def team_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def team_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the team
         """
         return pulumi.get(self, "team_id")
 
     @team_id.setter
-    def team_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def team_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "team_id", value)
 
     @_builtins.property
     @pulumi.getter(name="userId")
-    def user_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def user_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the user to add to the team
         """
         return pulumi.get(self, "user_id")
 
     @user_id.setter
-    def user_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def user_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "user_id", value)
 
 
@@ -102,8 +102,8 @@ class TeamMembership(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 team_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 user_id: Optional[pulumi.Input[_builtins.str]] = None,
+                 team_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 user_id: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         Manages a single user's membership in an Astro team. Use this resource instead of the `member_ids` attribute on `Team` when you need to manage memberships independently or across multiple state files.
@@ -143,8 +143,8 @@ class TeamMembership(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 team_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 user_id: Optional[pulumi.Input[_builtins.str]] = None,
+                 team_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 user_id: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -170,8 +170,8 @@ class TeamMembership(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            team_id: Optional[pulumi.Input[_builtins.str]] = None,
-            user_id: Optional[pulumi.Input[_builtins.str]] = None) -> 'TeamMembership':
+            team_id: pulumi.Input[Optional[_builtins.str]] = None,
+            user_id: pulumi.Input[Optional[_builtins.str]] = None) -> 'TeamMembership':
         """
         Get an existing TeamMembership resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/team_roles.py
+++ b/sdk/python/pulumi_astronomer/team_roles.py
@@ -23,9 +23,9 @@ class TeamRolesArgs:
     def __init__(__self__, *,
                  organization_role: pulumi.Input[_builtins.str],
                  team_id: pulumi.Input[_builtins.str],
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]] = None):
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]] = None):
         """
         The set of arguments for constructing a TeamRoles resource.
 
@@ -70,49 +70,49 @@ class TeamRolesArgs:
 
     @_builtins.property
     @pulumi.getter(name="dagRoles")
-    def dag_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]]:
+    def dag_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]]:
         """
         The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (e.g. with `DEPLOYMENT_ACCESSOR` role).
         """
         return pulumi.get(self, "dag_roles")
 
     @dag_roles.setter
-    def dag_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]]):
+    def dag_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]]):
         pulumi.set(self, "dag_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentRoles")
-    def deployment_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]]:
+    def deployment_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]]:
         """
         The roles to assign to the deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.
         """
         return pulumi.get(self, "deployment_roles")
 
     @deployment_roles.setter
-    def deployment_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]]):
+    def deployment_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]]):
         pulumi.set(self, "deployment_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceRoles")
-    def workspace_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]]:
+    def workspace_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]]:
         """
         The roles to assign to the workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
         """
         return pulumi.get(self, "workspace_roles")
 
     @workspace_roles.setter
-    def workspace_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]]):
+    def workspace_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]]):
         pulumi.set(self, "workspace_roles", value)
 
 
 @pulumi.input_type
 class _TeamRolesState:
     def __init__(__self__, *,
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]] = None,
-                 organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-                 team_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]] = None):
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]] = None,
+                 organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+                 team_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]] = None):
         """
         Input properties used for looking up and filtering TeamRoles resources.
 
@@ -135,62 +135,62 @@ class _TeamRolesState:
 
     @_builtins.property
     @pulumi.getter(name="dagRoles")
-    def dag_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]]:
+    def dag_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]]:
         """
         The DAG roles to assign to the team. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (e.g. with `DEPLOYMENT_ACCESSOR` role).
         """
         return pulumi.get(self, "dag_roles")
 
     @dag_roles.setter
-    def dag_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]]):
+    def dag_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDagRoleArgs']]]]):
         pulumi.set(self, "dag_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentRoles")
-    def deployment_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]]:
+    def deployment_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]]:
         """
         The roles to assign to the deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.
         """
         return pulumi.get(self, "deployment_roles")
 
     @deployment_roles.setter
-    def deployment_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]]):
+    def deployment_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesDeploymentRoleArgs']]]]):
         pulumi.set(self, "deployment_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="organizationRole")
-    def organization_role(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def organization_role(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The role to assign to the organization
         """
         return pulumi.get(self, "organization_role")
 
     @organization_role.setter
-    def organization_role(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def organization_role(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "organization_role", value)
 
     @_builtins.property
     @pulumi.getter(name="teamId")
-    def team_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def team_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the team to assign the roles to
         """
         return pulumi.get(self, "team_id")
 
     @team_id.setter
-    def team_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def team_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "team_id", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceRoles")
-    def workspace_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]]:
+    def workspace_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]]:
         """
         The roles to assign to the workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
         """
         return pulumi.get(self, "workspace_roles")
 
     @workspace_roles.setter
-    def workspace_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]]):
+    def workspace_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['TeamRolesWorkspaceRoleArgs']]]]):
         pulumi.set(self, "workspace_roles", value)
 
 
@@ -200,11 +200,11 @@ class TeamRoles(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamRolesDagRoleArgs', 'TeamRolesDagRoleArgsDict']]]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamRolesDeploymentRoleArgs', 'TeamRolesDeploymentRoleArgsDict']]]]] = None,
-                 organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-                 team_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamRolesWorkspaceRoleArgs', 'TeamRolesWorkspaceRoleArgsDict']]]]] = None,
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamRolesDagRoleArgs', 'TeamRolesDagRoleArgsDict']]]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamRolesDeploymentRoleArgs', 'TeamRolesDeploymentRoleArgsDict']]]]] = None,
+                 organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+                 team_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamRolesWorkspaceRoleArgs', 'TeamRolesWorkspaceRoleArgsDict']]]]] = None,
                  __props__=None):
         """
         Manages organization, workspace, deployment, and DAG roles for an existing team. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.
@@ -243,11 +243,11 @@ class TeamRoles(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamRolesDagRoleArgs', 'TeamRolesDagRoleArgsDict']]]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamRolesDeploymentRoleArgs', 'TeamRolesDeploymentRoleArgsDict']]]]] = None,
-                 organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-                 team_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamRolesWorkspaceRoleArgs', 'TeamRolesWorkspaceRoleArgsDict']]]]] = None,
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamRolesDagRoleArgs', 'TeamRolesDagRoleArgsDict']]]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamRolesDeploymentRoleArgs', 'TeamRolesDeploymentRoleArgsDict']]]]] = None,
+                 organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+                 team_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamRolesWorkspaceRoleArgs', 'TeamRolesWorkspaceRoleArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -276,11 +276,11 @@ class TeamRoles(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamRolesDagRoleArgs', 'TeamRolesDagRoleArgsDict']]]]] = None,
-            deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamRolesDeploymentRoleArgs', 'TeamRolesDeploymentRoleArgsDict']]]]] = None,
-            organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-            team_id: Optional[pulumi.Input[_builtins.str]] = None,
-            workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['TeamRolesWorkspaceRoleArgs', 'TeamRolesWorkspaceRoleArgsDict']]]]] = None) -> 'TeamRoles':
+            dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamRolesDagRoleArgs', 'TeamRolesDagRoleArgsDict']]]]] = None,
+            deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamRolesDeploymentRoleArgs', 'TeamRolesDeploymentRoleArgsDict']]]]] = None,
+            organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+            team_id: pulumi.Input[Optional[_builtins.str]] = None,
+            workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['TeamRolesWorkspaceRoleArgs', 'TeamRolesWorkspaceRoleArgsDict']]]]] = None) -> 'TeamRoles':
         """
         Get an existing TeamRoles resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/user_invite.py
+++ b/sdk/python/pulumi_astronomer/user_invite.py
@@ -60,13 +60,13 @@ class UserInviteArgs:
 @pulumi.input_type
 class _UserInviteState:
     def __init__(__self__, *,
-                 email: Optional[pulumi.Input[_builtins.str]] = None,
-                 expires_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 invite_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 invitee: Optional[pulumi.Input['UserInviteInviteeArgs']] = None,
-                 inviter: Optional[pulumi.Input['UserInviteInviterArgs']] = None,
-                 role: Optional[pulumi.Input[_builtins.str]] = None,
-                 user_id: Optional[pulumi.Input[_builtins.str]] = None):
+                 email: pulumi.Input[Optional[_builtins.str]] = None,
+                 expires_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 invite_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 invitee: pulumi.Input[Optional['UserInviteInviteeArgs']] = None,
+                 inviter: pulumi.Input[Optional['UserInviteInviterArgs']] = None,
+                 role: pulumi.Input[Optional[_builtins.str]] = None,
+                 user_id: pulumi.Input[Optional[_builtins.str]] = None):
         """
         Input properties used for looking up and filtering UserInvite resources.
 
@@ -95,86 +95,86 @@ class _UserInviteState:
 
     @_builtins.property
     @pulumi.getter
-    def email(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def email(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The email address of the user being invited
         """
         return pulumi.get(self, "email")
 
     @email.setter
-    def email(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def email(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "email", value)
 
     @_builtins.property
     @pulumi.getter(name="expiresAt")
-    def expires_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def expires_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The expiration date of the invite
         """
         return pulumi.get(self, "expires_at")
 
     @expires_at.setter
-    def expires_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def expires_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "expires_at", value)
 
     @_builtins.property
     @pulumi.getter(name="inviteId")
-    def invite_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def invite_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the invite
         """
         return pulumi.get(self, "invite_id")
 
     @invite_id.setter
-    def invite_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def invite_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "invite_id", value)
 
     @_builtins.property
     @pulumi.getter
-    def invitee(self) -> Optional[pulumi.Input['UserInviteInviteeArgs']]:
+    def invitee(self) -> pulumi.Input[Optional['UserInviteInviteeArgs']]:
         """
         The profile of the invitee
         """
         return pulumi.get(self, "invitee")
 
     @invitee.setter
-    def invitee(self, value: Optional[pulumi.Input['UserInviteInviteeArgs']]):
+    def invitee(self, value: pulumi.Input[Optional['UserInviteInviteeArgs']]):
         pulumi.set(self, "invitee", value)
 
     @_builtins.property
     @pulumi.getter
-    def inviter(self) -> Optional[pulumi.Input['UserInviteInviterArgs']]:
+    def inviter(self) -> pulumi.Input[Optional['UserInviteInviterArgs']]:
         """
         The profile of the inviter
         """
         return pulumi.get(self, "inviter")
 
     @inviter.setter
-    def inviter(self, value: Optional[pulumi.Input['UserInviteInviterArgs']]):
+    def inviter(self, value: pulumi.Input[Optional['UserInviteInviterArgs']]):
         pulumi.set(self, "inviter", value)
 
     @_builtins.property
     @pulumi.getter
-    def role(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def role(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The Organization role to assign to the user
         """
         return pulumi.get(self, "role")
 
     @role.setter
-    def role(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def role(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "role", value)
 
     @_builtins.property
     @pulumi.getter(name="userId")
-    def user_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def user_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the user
         """
         return pulumi.get(self, "user_id")
 
     @user_id.setter
-    def user_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def user_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "user_id", value)
 
 
@@ -184,8 +184,8 @@ class UserInvite(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 email: Optional[pulumi.Input[_builtins.str]] = None,
-                 role: Optional[pulumi.Input[_builtins.str]] = None,
+                 email: pulumi.Input[Optional[_builtins.str]] = None,
+                 role: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         User Invite resource
@@ -243,8 +243,8 @@ class UserInvite(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 email: Optional[pulumi.Input[_builtins.str]] = None,
-                 role: Optional[pulumi.Input[_builtins.str]] = None,
+                 email: pulumi.Input[Optional[_builtins.str]] = None,
+                 role: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -275,13 +275,13 @@ class UserInvite(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            email: Optional[pulumi.Input[_builtins.str]] = None,
-            expires_at: Optional[pulumi.Input[_builtins.str]] = None,
-            invite_id: Optional[pulumi.Input[_builtins.str]] = None,
-            invitee: Optional[pulumi.Input[Union['UserInviteInviteeArgs', 'UserInviteInviteeArgsDict']]] = None,
-            inviter: Optional[pulumi.Input[Union['UserInviteInviterArgs', 'UserInviteInviterArgsDict']]] = None,
-            role: Optional[pulumi.Input[_builtins.str]] = None,
-            user_id: Optional[pulumi.Input[_builtins.str]] = None) -> 'UserInvite':
+            email: pulumi.Input[Optional[_builtins.str]] = None,
+            expires_at: pulumi.Input[Optional[_builtins.str]] = None,
+            invite_id: pulumi.Input[Optional[_builtins.str]] = None,
+            invitee: pulumi.Input[Optional[Union['UserInviteInviteeArgs', 'UserInviteInviteeArgsDict']]] = None,
+            inviter: pulumi.Input[Optional[Union['UserInviteInviterArgs', 'UserInviteInviterArgsDict']]] = None,
+            role: pulumi.Input[Optional[_builtins.str]] = None,
+            user_id: pulumi.Input[Optional[_builtins.str]] = None) -> 'UserInvite':
         """
         Get an existing UserInvite resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/user_roles.py
+++ b/sdk/python/pulumi_astronomer/user_roles.py
@@ -23,9 +23,9 @@ class UserRolesArgs:
     def __init__(__self__, *,
                  organization_role: pulumi.Input[_builtins.str],
                  user_id: pulumi.Input[_builtins.str],
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]] = None):
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]] = None):
         """
         The set of arguments for constructing a UserRoles resource.
 
@@ -70,49 +70,49 @@ class UserRolesArgs:
 
     @_builtins.property
     @pulumi.getter(name="dagRoles")
-    def dag_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]]:
+    def dag_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]]:
         """
         The DAG roles to assign to the user. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (e.g. with `DEPLOYMENT_ACCESSOR` role).
         """
         return pulumi.get(self, "dag_roles")
 
     @dag_roles.setter
-    def dag_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]]):
+    def dag_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]]):
         pulumi.set(self, "dag_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentRoles")
-    def deployment_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]]:
+    def deployment_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]]:
         """
         The roles to assign to the deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.
         """
         return pulumi.get(self, "deployment_roles")
 
     @deployment_roles.setter
-    def deployment_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]]):
+    def deployment_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]]):
         pulumi.set(self, "deployment_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceRoles")
-    def workspace_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]]:
+    def workspace_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]]:
         """
         The roles to assign to the workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
         """
         return pulumi.get(self, "workspace_roles")
 
     @workspace_roles.setter
-    def workspace_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]]):
+    def workspace_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]]):
         pulumi.set(self, "workspace_roles", value)
 
 
 @pulumi.input_type
 class _UserRolesState:
     def __init__(__self__, *,
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]] = None,
-                 organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-                 user_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]] = None):
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]] = None,
+                 organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+                 user_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]] = None):
         """
         Input properties used for looking up and filtering UserRoles resources.
 
@@ -135,62 +135,62 @@ class _UserRolesState:
 
     @_builtins.property
     @pulumi.getter(name="dagRoles")
-    def dag_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]]:
+    def dag_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]]:
         """
         The DAG roles to assign to the user. Each role grants permissions to a specific DAG or DAGs with a specific tag within a deployment. Each deployment referenced in `dag_roles` must also have a corresponding entry in `deployment_roles` (e.g. with `DEPLOYMENT_ACCESSOR` role).
         """
         return pulumi.get(self, "dag_roles")
 
     @dag_roles.setter
-    def dag_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]]):
+    def dag_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDagRoleArgs']]]]):
         pulumi.set(self, "dag_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="deploymentRoles")
-    def deployment_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]]:
+    def deployment_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]]:
         """
         The roles to assign to the deployments. Each `deployment_id` must belong to a workspace that also appears in `workspace_roles`. Required for any deployment referenced in `dag_roles`.
         """
         return pulumi.get(self, "deployment_roles")
 
     @deployment_roles.setter
-    def deployment_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]]):
+    def deployment_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesDeploymentRoleArgs']]]]):
         pulumi.set(self, "deployment_roles", value)
 
     @_builtins.property
     @pulumi.getter(name="organizationRole")
-    def organization_role(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def organization_role(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The role to assign to the organization
         """
         return pulumi.get(self, "organization_role")
 
     @organization_role.setter
-    def organization_role(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def organization_role(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "organization_role", value)
 
     @_builtins.property
     @pulumi.getter(name="userId")
-    def user_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def user_id(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         The ID of the user to assign the roles to
         """
         return pulumi.get(self, "user_id")
 
     @user_id.setter
-    def user_id(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def user_id(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "user_id", value)
 
     @_builtins.property
     @pulumi.getter(name="workspaceRoles")
-    def workspace_roles(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]]:
+    def workspace_roles(self) -> pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]]:
         """
         The roles to assign to the workspaces. When you set `deployment_roles` or `dag_roles`, include each deployment's parent workspace here (any workspace role), so Terraform state matches the API.
         """
         return pulumi.get(self, "workspace_roles")
 
     @workspace_roles.setter
-    def workspace_roles(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]]):
+    def workspace_roles(self, value: pulumi.Input[Optional[Sequence[pulumi.Input['UserRolesWorkspaceRoleArgs']]]]):
         pulumi.set(self, "workspace_roles", value)
 
 
@@ -200,11 +200,11 @@ class UserRoles(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['UserRolesDagRoleArgs', 'UserRolesDagRoleArgsDict']]]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['UserRolesDeploymentRoleArgs', 'UserRolesDeploymentRoleArgsDict']]]]] = None,
-                 organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-                 user_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['UserRolesWorkspaceRoleArgs', 'UserRolesWorkspaceRoleArgsDict']]]]] = None,
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['UserRolesDagRoleArgs', 'UserRolesDagRoleArgsDict']]]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['UserRolesDeploymentRoleArgs', 'UserRolesDeploymentRoleArgsDict']]]]] = None,
+                 organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+                 user_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['UserRolesWorkspaceRoleArgs', 'UserRolesWorkspaceRoleArgsDict']]]]] = None,
                  __props__=None):
         """
         Manages organization, workspace, deployment, and DAG roles for a user. Astro permissions are hierarchical (organization, workspace, deployment, then DAG). Declare roles at each applicable parent scope as well as nested scopes, not only at the leaf, so Terraform state matches the API.
@@ -243,11 +243,11 @@ class UserRoles(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['UserRolesDagRoleArgs', 'UserRolesDagRoleArgsDict']]]]] = None,
-                 deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['UserRolesDeploymentRoleArgs', 'UserRolesDeploymentRoleArgsDict']]]]] = None,
-                 organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-                 user_id: Optional[pulumi.Input[_builtins.str]] = None,
-                 workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['UserRolesWorkspaceRoleArgs', 'UserRolesWorkspaceRoleArgsDict']]]]] = None,
+                 dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['UserRolesDagRoleArgs', 'UserRolesDagRoleArgsDict']]]]] = None,
+                 deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['UserRolesDeploymentRoleArgs', 'UserRolesDeploymentRoleArgsDict']]]]] = None,
+                 organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+                 user_id: pulumi.Input[Optional[_builtins.str]] = None,
+                 workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['UserRolesWorkspaceRoleArgs', 'UserRolesWorkspaceRoleArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -276,11 +276,11 @@ class UserRoles(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            dag_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['UserRolesDagRoleArgs', 'UserRolesDagRoleArgsDict']]]]] = None,
-            deployment_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['UserRolesDeploymentRoleArgs', 'UserRolesDeploymentRoleArgsDict']]]]] = None,
-            organization_role: Optional[pulumi.Input[_builtins.str]] = None,
-            user_id: Optional[pulumi.Input[_builtins.str]] = None,
-            workspace_roles: Optional[pulumi.Input[Sequence[pulumi.Input[Union['UserRolesWorkspaceRoleArgs', 'UserRolesWorkspaceRoleArgsDict']]]]] = None) -> 'UserRoles':
+            dag_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['UserRolesDagRoleArgs', 'UserRolesDagRoleArgsDict']]]]] = None,
+            deployment_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['UserRolesDeploymentRoleArgs', 'UserRolesDeploymentRoleArgsDict']]]]] = None,
+            organization_role: pulumi.Input[Optional[_builtins.str]] = None,
+            user_id: pulumi.Input[Optional[_builtins.str]] = None,
+            workspace_roles: pulumi.Input[Optional[Sequence[pulumi.Input[Union['UserRolesWorkspaceRoleArgs', 'UserRolesWorkspaceRoleArgsDict']]]]] = None) -> 'UserRoles':
         """
         Get an existing UserRoles resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.

--- a/sdk/python/pulumi_astronomer/workspace.py
+++ b/sdk/python/pulumi_astronomer/workspace.py
@@ -23,7 +23,7 @@ class WorkspaceArgs:
     def __init__(__self__, *,
                  cicd_enforced_default: pulumi.Input[_builtins.bool],
                  description: pulumi.Input[_builtins.str],
-                 name: Optional[pulumi.Input[_builtins.str]] = None):
+                 name: pulumi.Input[Optional[_builtins.str]] = None):
         """
         The set of arguments for constructing a Workspace resource.
 
@@ -62,27 +62,27 @@ class WorkspaceArgs:
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Workspace name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
 
 @pulumi.input_type
 class _WorkspaceState:
     def __init__(__self__, *,
-                 cicd_enforced_default: Optional[pulumi.Input[_builtins.bool]] = None,
-                 created_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 created_by: Optional[pulumi.Input['WorkspaceCreatedByArgs']] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-                 updated_by: Optional[pulumi.Input['WorkspaceUpdatedByArgs']] = None):
+                 cicd_enforced_default: pulumi.Input[Optional[_builtins.bool]] = None,
+                 created_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 created_by: pulumi.Input[Optional['WorkspaceCreatedByArgs']] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+                 updated_by: pulumi.Input[Optional['WorkspaceUpdatedByArgs']] = None):
         """
         Input properties used for looking up and filtering Workspace resources.
 
@@ -111,86 +111,86 @@ class _WorkspaceState:
 
     @_builtins.property
     @pulumi.getter(name="cicdEnforcedDefault")
-    def cicd_enforced_default(self) -> Optional[pulumi.Input[_builtins.bool]]:
+    def cicd_enforced_default(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
         Whether new Deployments enforce CI/CD deploys by default
         """
         return pulumi.get(self, "cicd_enforced_default")
 
     @cicd_enforced_default.setter
-    def cicd_enforced_default(self, value: Optional[pulumi.Input[_builtins.bool]]):
+    def cicd_enforced_default(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "cicd_enforced_default", value)
 
     @_builtins.property
     @pulumi.getter(name="createdAt")
-    def created_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def created_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Workspace creation timestamp
         """
         return pulumi.get(self, "created_at")
 
     @created_at.setter
-    def created_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def created_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "created_at", value)
 
     @_builtins.property
     @pulumi.getter(name="createdBy")
-    def created_by(self) -> Optional[pulumi.Input['WorkspaceCreatedByArgs']]:
+    def created_by(self) -> pulumi.Input[Optional['WorkspaceCreatedByArgs']]:
         """
         Workspace creator
         """
         return pulumi.get(self, "created_by")
 
     @created_by.setter
-    def created_by(self, value: Optional[pulumi.Input['WorkspaceCreatedByArgs']]):
+    def created_by(self, value: pulumi.Input[Optional['WorkspaceCreatedByArgs']]):
         pulumi.set(self, "created_by", value)
 
     @_builtins.property
     @pulumi.getter
-    def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def description(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Workspace description
         """
         return pulumi.get(self, "description")
 
     @description.setter
-    def description(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def description(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "description", value)
 
     @_builtins.property
     @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def name(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Workspace name
         """
         return pulumi.get(self, "name")
 
     @name.setter
-    def name(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def name(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "name", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedAt")
-    def updated_at(self) -> Optional[pulumi.Input[_builtins.str]]:
+    def updated_at(self) -> pulumi.Input[Optional[_builtins.str]]:
         """
         Workspace last updated timestamp
         """
         return pulumi.get(self, "updated_at")
 
     @updated_at.setter
-    def updated_at(self, value: Optional[pulumi.Input[_builtins.str]]):
+    def updated_at(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "updated_at", value)
 
     @_builtins.property
     @pulumi.getter(name="updatedBy")
-    def updated_by(self) -> Optional[pulumi.Input['WorkspaceUpdatedByArgs']]:
+    def updated_by(self) -> pulumi.Input[Optional['WorkspaceUpdatedByArgs']]:
         """
         Workspace updater
         """
         return pulumi.get(self, "updated_by")
 
     @updated_by.setter
-    def updated_by(self, value: Optional[pulumi.Input['WorkspaceUpdatedByArgs']]):
+    def updated_by(self, value: pulumi.Input[Optional['WorkspaceUpdatedByArgs']]):
         pulumi.set(self, "updated_by", value)
 
 
@@ -200,9 +200,9 @@ class Workspace(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cicd_enforced_default: Optional[pulumi.Input[_builtins.bool]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
+                 cicd_enforced_default: pulumi.Input[Optional[_builtins.bool]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         """
         Workspace resource
@@ -239,9 +239,9 @@ class Workspace(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 cicd_enforced_default: Optional[pulumi.Input[_builtins.bool]] = None,
-                 description: Optional[pulumi.Input[_builtins.str]] = None,
-                 name: Optional[pulumi.Input[_builtins.str]] = None,
+                 cicd_enforced_default: pulumi.Input[Optional[_builtins.bool]] = None,
+                 description: pulumi.Input[Optional[_builtins.str]] = None,
+                 name: pulumi.Input[Optional[_builtins.str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -272,13 +272,13 @@ class Workspace(pulumi.CustomResource):
     def get(resource_name: str,
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
-            cicd_enforced_default: Optional[pulumi.Input[_builtins.bool]] = None,
-            created_at: Optional[pulumi.Input[_builtins.str]] = None,
-            created_by: Optional[pulumi.Input[Union['WorkspaceCreatedByArgs', 'WorkspaceCreatedByArgsDict']]] = None,
-            description: Optional[pulumi.Input[_builtins.str]] = None,
-            name: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_at: Optional[pulumi.Input[_builtins.str]] = None,
-            updated_by: Optional[pulumi.Input[Union['WorkspaceUpdatedByArgs', 'WorkspaceUpdatedByArgsDict']]] = None) -> 'Workspace':
+            cicd_enforced_default: pulumi.Input[Optional[_builtins.bool]] = None,
+            created_at: pulumi.Input[Optional[_builtins.str]] = None,
+            created_by: pulumi.Input[Optional[Union['WorkspaceCreatedByArgs', 'WorkspaceCreatedByArgsDict']]] = None,
+            description: pulumi.Input[Optional[_builtins.str]] = None,
+            name: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_at: pulumi.Input[Optional[_builtins.str]] = None,
+            updated_by: pulumi.Input[Optional[Union['WorkspaceUpdatedByArgs', 'WorkspaceUpdatedByArgsDict']]] = None) -> 'Workspace':
         """
         Get an existing Workspace resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.


### PR DESCRIPTION
## Summary

The \`build_sdk\` matrix's \`Check worktree clean\` step has been failing on every PR because the checked-in SDKs were regenerated against an older pulumi than what CI installs.

\`mise.toml\` / \`mise.ci.toml\` have \`pulumi = \"latest\"\`, which mise resolves at install time. CI today gets pulumi 3.233.0; the developer machine that last regenerated the SDKs was on 3.232.0. The codegen contract for optional input properties changed between those releases:

- **Python**: \`Optional[pulumi.Input[X]]\` → \`pulumi.Input[Optional[X]]\`
- **TypeScript**: \`Input<X>\` + \`?:\` → \`Input<X | undefined>\`
- (Equivalent shape changes in Go and .NET.)

So every regen-check on PR was diffing against stale output.

## Changes

1. **Pin \`pulumi = \"3.233.0\"\`** in both \`mise.toml\` and \`mise.ci.toml\`. Future bumps are explicit edits, no more silent drift.
2. **Regenerate all four SDKs** with 3.233.0. Diff is purely structural; no behavior change. Verified by running the regen locally with \`PATH=.../pulumi/3.233.0/... make build_sdks\` after the pin.

## Test plan

- [ ] CI \`build_sdk (python|nodejs|go|dotnet)\` should now pass — worktree clean after regen against the pinned pulumi.
- [ ] Existing consumers see no behavior change; the type wrappers are semantically equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)