### PR TITLE
docs(rules): verify-before-claiming + version-pinning-via-lockfile

### DIFF
--- a/.claude/rules/verify-before-claiming.md
+++ b/.claude/rules/verify-before-claiming.md
@@ -1,0 +1,33 @@
+---
+description: Don't claim a root cause from circumstantial evidence — run an experiment that isolates the suspected variable before asserting "this is why X fails". The user has pushed back twice when I shipped "this is the bug" without verifying.
+paths:
+  - "**/*"
+---
+
+# Verify Before Claiming
+
+When diagnosing a CI failure, behavior delta, or "X is broken because Y", verify the causal link before stating it. Inferring from circumstantial evidence ("there's a version skew → that must be the cause") is not the same as proving it ("ran with version A, ran with version B, observed the delta").
+
+## Tells you're inferring, not verifying
+
+- Hedged language: "this is likely…", "it must be that…", "consistent with the theory that…".
+- Citing a fact that *could* be related, with no test that connects it to the failure.
+- "Local matches what's checked in" — proves consistency between dev and repo; says nothing about CI's runtime.
+
+## How to verify (concrete examples)
+
+- **Suspected version drift** (e.g. `pulumi 3.232.0` vs `3.233.0` codegen): install both, run codegen with each, diff the output. Confirm the delta matches what CI sees.
+- **Suspected platform drift** (Mac vs Linux): run the same binary in a Linux container (`podman run --platform linux/amd64 ...`) and compare against Mac output.
+- **Suspected env / permissions**: replicate the env (token type, CI runner image, locale) and reproduce.
+
+For any of these, the test is: "if I'm right, *this specific output* should appear / not appear."
+
+## When you can't verify locally
+
+Say so explicitly: "I haven't verified this is the cause; my best guess is X based on Y, but the test would be Z." Don't propose fixes predicated on unverified diagnosis.
+
+## Don't
+
+- Don't call a CI failure "transient" without evidence — a single retry passing can be unrelated to the bug.
+- Don't conflate "matches checked-in state" with "matches CI's build" — different consistency claims.
+- Don't reach for an admin-merge / bypass before you've actually proved the failing check is unrelated.

--- a/.claude/rules/version-pinning-via-lockfile.md
+++ b/.claude/rules/version-pinning-via-lockfile.md
@@ -1,0 +1,31 @@
+---
+description: Pin exact tool versions in mise.lock, not in mise.toml. Declarations stay loose (e.g. `pulumi = "3"`) so `mise up` works ergonomically; the lockfile is the single source of truth for "what version is everyone on right now".
+paths:
+  - "mise.toml"
+  - "mise.ci.toml"
+  - "mise.lock"
+  - ".github/actions/setup-mise/action.yml"
+---
+
+# Version Pinning via mise.lock
+
+`mise.toml` and `mise.ci.toml` declare **ranges** (`pulumi = "3"`, `golangci-lint = "2"`). `mise.lock` pins **exact** versions (`pulumi 3.233.0`, `golangci-lint 2.11.4`). Same model as `package.json` + `package-lock.json`.
+
+`[settings] lockfile = true` is set in both mise files; `mise install` reads from the lockfile when present.
+
+## Bumping
+
+- `mise up` — upgrade within the declared range, update `mise.lock`. (e.g. `pulumi = "3"` lets it move from 3.233.0 to 3.234.0.)
+- `mise up --bump` — widen the range in `mise.toml` and update `mise.lock`. (e.g. `pulumi 3` → `pulumi 4`.)
+
+Either way, commit the resulting `mise.lock` change as part of the bump.
+
+## CI plumbing
+
+`.github/actions/setup-mise/action.yml` stages both `mise.ci.toml` (renamed to `mise.toml` in `$RUNNER_TEMP/mise-ci/`) **and** `mise.lock` so mise-action installs from the lockfile. If you forget the `mise.lock` copy, CI silently falls back to range resolution and drift returns.
+
+## Don't
+
+- Don't pin exact versions in `mise.toml` (e.g. `pulumi = "3.233.0"`) to fix a drift bug — that's the wrong layer. Lockfile is the right place; the declaration should describe intent ("we want pulumi 3.x"), not the snapshot.
+- Don't leave a tool unpinned (e.g. `golangci-lint = "2"` with no lockfile entry) — silent minor-version drift breaks CI when new lint rules ship.
+- Don't `mise use --pin <tool>@<version>` to pin via the lockfile — that flag writes the exact version into `mise.toml`, the opposite of what we want. Use `mise install <tool>@<version>` then `mise lock`.


### PR DESCRIPTION
## Summary

Two project rules captured from the upgrade-provider debugging session.

- [verify-before-claiming.md](.claude/rules/verify-before-claiming.md) — Don't assert "X is broken because Y" from circumstantial evidence. Run an experiment that isolates the variable (e.g. install both versions, run codegen with each, diff) before stating the diagnosis. Hedged words like "likely" / "must be" are tells you're inferring, not verifying.
- [version-pinning-via-lockfile.md](.claude/rules/version-pinning-via-lockfile.md) — Tool versions belong in \`mise.lock\`, not in \`mise.toml\`. Declarations stay loose (\`pulumi = "3"\`) so \`mise up\` works; the lockfile is the snapshot. Avoid \`mise use --pin\` (writes exact version into the wrong file).

## Why these two

I made each mistake during the upgrade-provider debugging on this branch:

1. Claimed Mac vs Linux platform was the root cause of SDK codegen drift; user pushed back with "have you checked?" — actual cause was a pulumi 3.232.0 vs 3.233.0 codegen contract change.
2. "Fixed" pulumi version drift by hard-pinning \`pulumi = "3.233.0"\` in \`mise.toml\`; user pushed back: "we can't run a \`mise up\` to just get to the next version. Isn't this level of pinning what the lockfiles are for?" — moved to \`mise.lock\` in the same PR.

## Test plan

- [ ] Rules are discovered as documentation only — no code paths to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)